### PR TITLE
chore(github): Update Issue Templates with default project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,7 @@ about: Report something that doesn't work
 title: ''
 labels: bug
 assignees: ''
+projects: 1-Platform/1
 
 ---
 
@@ -31,17 +32,11 @@ For the fastest support, provide a working demo or minimal reproduction using to
 ## Screenshots:
 <!-- If applicable, add screenshots to help explain your problem. -->
 
-Environment
-   - [ ] Operating System(s): 
-       - [ ] Linux [Variant and Version]
-       - [ ] macOS [Variant and Version]
-       - [ ] Windows [Variant and Version]
-   - [ ] Browser(s)
-       - [ ] Firefox [Version]
-       - [ ] Chrome [Version]
-       - [ ] Safari [Version]
-       - [ ] Other (please specify) 
-   - [ ] Other: please specify [Variant and Version]
+
+## Environment;
+
+- Operating System(s): Linux/macOS/Windows [Variant and Version]
+- Browser: Firefox/Chrome/Safari [Version] / Other (please specify)
 
 ## Tell us more about your product/project and timeline to help prioritize this issue:
 <!--

--- a/.github/ISSUE_TEMPLATE/documentation_proposal.md
+++ b/.github/ISSUE_TEMPLATE/documentation_proposal.md
@@ -4,6 +4,7 @@ about: Propose documentation improvements / additions
 title: ''
 labels: documentation
 assignees: ''
+projects: 1-Platform/1
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,7 @@ about: Suggest an idea for this project
 title: ''
 labels: enhancement
 assignees: ''
+projects: 1-Platform/1
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/regression_report.md
+++ b/.github/ISSUE_TEMPLATE/regression_report.md
@@ -4,6 +4,7 @@ about: Tell us about something that worked at one point and now doesn't
 title: ''
 labels: regression
 assignees: ''
+projects: 1-Platform/1
 
 ---
 
@@ -30,17 +31,10 @@ For the fastest support, provide a working demo or minimal reproduction using to
 ## Screenshots:
 <!-- If applicable, add screenshots to help explain your problem. -->
 
-## Environment:
-   - [ ] Operating System(s): 
-       - [ ] Linux [Variant and Version]
-       - [ ] macOS [Variant and Version]
-       - [ ] Windows [Variant and Version]
-   - [ ] Browser(s)
-       - [ ] Firefox [Version]
-       - [ ] Chrome [Version]
-       - [ ] Safari [Version]
-       - [ ] Other (please specify) 
-   - [ ] Other: please specify [Variant and Version]
+## Environment;
+
+- Operating System(s): Linux/macOS/Windows [Variant and Version]
+- Browser: Firefox/Chrome/Safari [Version] / Other (please specify)
 
 ## Tell us more about your product/project and timeline to help prioritize this issue:
 <!--


### PR DESCRIPTION
## Describe the changes:

Added default project to the issue templates so the issue is automatically added to the [One Platform Development Board](https://github.com/orgs/1-Platform/projects/1).

And removed some checklists from the templates.

## Does this PR introduce a breaking change?

No
