### PR TITLE
fix(#254) -  Add feedback microservice information to the microservice details page

### DIFF
--- a/packages/home-spa/src/js/controller.js
+++ b/packages/home-spa/src/js/controller.js
@@ -10,6 +10,7 @@ import '../img/magnifying-glass.svg';
 import '../img/Auth-illustration.svg';
 import '../img/Notification-illustration.svg';
 import '../img/User-profile-illustration.svg';
+import '../img/Feedback-illustration.svg';
 import '../img/user-female.svg';
 import '../img/user-male.svg';
 

--- a/packages/home-spa/src/mocks/stub.js
+++ b/packages/home-spa/src/mocks/stub.js
@@ -117,7 +117,7 @@ export const microserviceDetailsMock = [
          'Allow users to share user experience feedback and feature requests',
          'JIRA integration to automatically create JIRAs for every feedback',
       ],
-      illustration: 'img/Notification-illustration.svg',
+      illustration: 'img/Feedback-illustration.svg',
    }
 ];
 

--- a/packages/home-spa/src/mocks/stub.js
+++ b/packages/home-spa/src/mocks/stub.js
@@ -115,7 +115,7 @@ export const microserviceDetailsMock = [
       features: [
          'Provide feedback for the Platform or the hosted apps from anywhere',
          'Allow users to share user experience feedback and feature requests',
-         'JIRA integration to automatically create JIRAs for every feedback',
+         'JIRA integration to automatically create JIRA tasks for every feedback',
       ],
       illustration: 'img/Feedback-illustration.svg',
    }

--- a/packages/home-spa/src/mocks/stub.js
+++ b/packages/home-spa/src/mocks/stub.js
@@ -76,7 +76,7 @@ export const stub = [
 export const microserviceDetailsMock = [
    {
       title: 'Authentication',
-      info: 'Authentication microservices would verify and authenticate the legitimate user and grant necessary access.',
+      info: 'Authentication microservice will verify and authenticate the legitimate user and grant necessary access.',
       features: [
          'SSO integration.',
          'Authenticate SPA users using authentication microservice.',
@@ -92,7 +92,7 @@ export const microserviceDetailsMock = [
          'Manage & Support notifications between SPA’s hosted over One Platform.',
          'Manage SPA Subscriptions.',
          'Notification UI to view SPA specific notifications, configuration management dashboard.',
-         'Integration with User & Group microservice to notify targetted users.',
+         'Integration with User & Group microservice to notify targeted users.',
          'Integration with Hydra (near future).',
       ],
       illustration: 'img/Notification-illustration.svg',
@@ -109,6 +109,16 @@ export const microserviceDetailsMock = [
       ],
       illustration: 'img/User-profile-illustration.svg',
    },
+   {
+      title: 'Feedback',
+      info: `One platform's server-side Feedback GraphQL microservice. This microservice will allow users to talk to the feedback database and can perform operations like addFeedback, updateFeedback, deleteFeedback & listFeedback`,
+      features: [
+         'Provide feedback for the Platform or the hosted apps from anywhere',
+         'Allow users to share user experience feedback and feature requests',
+         'JIRA integration to automatically create JIRAs for every feedback',
+      ],
+      illustration: 'img/Notification-illustration.svg',
+   }
 ];
 
 export const teamMembers = [

--- a/packages/home-spa/src/mocks/stub.js
+++ b/packages/home-spa/src/mocks/stub.js
@@ -111,7 +111,7 @@ export const microserviceDetailsMock = [
    },
    {
       title: 'Feedback',
-      info: `One platform's server-side Feedback GraphQL microservice. This microservice will allow users to talk to the feedback database and can perform operations like addFeedback, updateFeedback, deleteFeedback & listFeedback`,
+      info: `One Platform's GraphQL based Feedback microservice. This microservice will allow users to talk to the feedback database and can perform operations like addFeedback, updateFeedback, deleteFeedback & listFeedback`,
       features: [
          'Provide feedback for the Platform or the hosted apps from anywhere',
          'Allow users to share user experience feedback and feature requests',


### PR DESCRIPTION
fix(#254) - Added feedback to stub

### Fixes #254 

#### Explain the feature/fix

Added the following object to the microserviceDetailsMock
```
   {
      title: 'Feedback',
      info: `One platform's server-side Feedback GraphQL microservice. This microservice will allow users to talk to the feedback database and can perform operations like addFeedback, updateFeedback, deleteFeedback & listFeedback`,
      features: [
         'Provide feedback for the Platform or the hosted apps from anywhere',
         'Allow users to share user experience feedback and feature requests',
         'JIRA integration to automatically create JIRAs for every feedback',
      ],
      illustration: 'img/Notification-illustration.svg',
   }
```
## Does this PR introduce a breaking change

No

## Screenshots

<img width="1680" alt="Screenshot 2020-05-06 at 5 42 20 PM" src="https://user-images.githubusercontent.com/12994292/81175322-0004dc00-8fc1-11ea-8c22-cf85bc99e142.png">


### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
- [x] Was this feature demoed and the design review approved?
