### PR TITLE
fix(#360) - Additional field for permissions in the Home Service Schema

### DIFF
--- a/packages/home-service/src/helpers.ts
+++ b/packages/home-service/src/helpers.ts
@@ -46,7 +46,7 @@ class HomeAPIHelper {
             query {
                 ${query}
         }`;
-        return fetch(`${process.env.USER_SERVICE_SERVICE_HOST}:${process.env.USER_SERVICE_SERVICE_PORT}/graphql`, {
+        return fetch(`http://${process.env.USER_SERVICE_SERVICE_HOST}:${process.env.USER_SERVICE_SERVICE_PORT}/graphql`, {
             method: 'post',
             body: JSON.stringify({query: body}),
             headers: { 'Content-Type': 'application/json' },

--- a/packages/home-service/src/schema.ts
+++ b/packages/home-service/src/schema.ts
@@ -13,6 +13,12 @@ export const HomeServiceSchema: Schema = new Schema({
     createdOn: Date,
     updatedBy: String,
     updatedOn: Date,
+    permissions: [
+        {
+            roverGroup: String,
+            role: String,
+        }
+    ],
 });
 
 interface HomeModel extends HomeType , Document { }

--- a/packages/home-service/src/schema.ts
+++ b/packages/home-service/src/schema.ts
@@ -16,7 +16,11 @@ export const HomeServiceSchema: Schema = new Schema({
     permissions: [
         {
             roverGroup: String,
-            role: String,
+            role: {
+                type: String,
+                enum: ['ADMIN', 'USER'],
+                required: true,
+            }
         }
     ],
 });

--- a/packages/home-service/src/typedef.graphql
+++ b/packages/home-service/src/typedef.graphql
@@ -23,56 +23,56 @@ type UserType {
   updatedOn: DateTime
 }
 type HomeType {
-    _id: String
-    name: String
-    description: String
-    link: String
-    icon: String
-    entityType: String
-    colorScheme: String
-    videoUrl: String
-    owners: [UserType]
-    createdBy: UserType
-    createdOn: DateTime
-    updatedBy: UserType
-    updatedOn: DateTime
-    permissions: [PermissionsType]
+  _id: String
+  name: String
+  description: String
+  link: String
+  icon: String
+  entityType: String
+  colorScheme: String
+  videoUrl: String
+  owners: [UserType]
+  createdBy: UserType
+  createdOn: DateTime
+  updatedBy: UserType
+  updatedOn: DateTime
+  permissions: [PermissionsType]
 }
 input PermissionsInput {
   roverGroup: String
-  role: APIROLE
+  role: APIROLE!
 }
 input HomeInput {
-    _id: String
-    name: String
-    description: String
-    link: String
-    icon: String
-    entityType: String
-    colorScheme: String
-    videoUrl: String
-    owners: [String]
-    createdBy: String
-    createdOn: DateTime
-    updatedBy: String
-    updatedOn: DateTime
-    permissions: [PermissionsInput]
+  _id: String
+  name: String
+  description: String
+  link: String
+  icon: String
+  entityType: String
+  colorScheme: String
+  videoUrl: String
+  owners: [String]
+  createdBy: String
+  createdOn: DateTime
+  updatedBy: String
+  updatedOn: DateTime
+  permissions: [PermissionsInput]
 }
 
 type Query {
-    # Fetches all HomeType
-    listHomeType: [HomeType]
-    # Fetches specific HomeType by id
-    getHomeType(_id: String!): [HomeType]
-    # Fetches HomeType by any property
-    getHomeTypeBy(input: HomeInput): [HomeType]
+  # Fetches all HomeType
+  listHomeType: [HomeType]
+  # Fetches specific HomeType by id
+  getHomeType(_id: String!): [HomeType]
+  # Fetches HomeType by any property
+  getHomeTypeBy(input: HomeInput): [HomeType]
 }
 
 type Mutation {
-    # Add HomeType
-    createHomeType(input: HomeInput): HomeType
-    # Update HomeType
-    updateHomeType(input: HomeInput): HomeType
-    # Delete HomeType by id
-    deleteHomeType(_id: String!): HomeType
+  # Add HomeType
+  createHomeType(input: HomeInput): HomeType
+  # Update HomeType
+  updateHomeType(input: HomeInput): HomeType
+  # Delete HomeType by id
+  deleteHomeType(_id: String!): HomeType
 }

--- a/packages/home-service/src/typedef.graphql
+++ b/packages/home-service/src/typedef.graphql
@@ -4,6 +4,10 @@ enum APIROLE {
   ADMIN
   USER
 }
+type PermissionsType {
+  roverGroup: String
+  role: APIROLE
+}
 type UserType {
   _id: String
   name: String
@@ -32,6 +36,11 @@ type HomeType {
     createdOn: DateTime
     updatedBy: UserType
     updatedOn: DateTime
+    permissions: [PermissionsType]
+}
+input PermissionsInput {
+  roverGroup: String
+  role: APIROLE
 }
 input HomeInput {
     _id: String
@@ -47,6 +56,7 @@ input HomeInput {
     createdOn: DateTime
     updatedBy: String
     updatedOn: DateTime
+    permissions: [PermissionsInput]
 }
 
 type Query {

--- a/packages/home-service/src/types.d.ts
+++ b/packages/home-service/src/types.d.ts
@@ -2,8 +2,8 @@ declare module '*.graphql';
 declare module '*.json';
 
 declare enum Role {
-  admin = "ADMIN",
-  user = "USER"
+  ADMIN = "ADMIN",
+  USER = "USER"
 }
 type PermissionsType = {
   roverGroup: string;

--- a/packages/home-service/src/types.d.ts
+++ b/packages/home-service/src/types.d.ts
@@ -1,35 +1,39 @@
 declare module '*.graphql';
 declare module '*.json';
 
+declare enum Role {
+  admin = "ADMIN",
+  user = "USER"
+}
 type PermissionsType = {
   roverGroup: string;
-  role: string;
+  role: Role;
 }
 type UserType = {
-    name: string;
-    title: string;
-    uid: string;
-    rhatUUID: string;
-    isActive ?: boolean;
-    memberOf: string[];
-    apiRole: string,
-    createdBy: string;
-    createdOn: Date;
-    updatedBy: string;
-    updatedOn: Date;
+  name: string;
+  title: string;
+  uid: string;
+  rhatUUID: string;
+  isActive ?: boolean;
+  memberOf: string[];
+  apiRole: string,
+  createdBy: string;
+  createdOn: Date;
+  updatedBy: string;
+  updatedOn: Date;
   }
 type HomeType = {
-    name: string;
-    description: string;
-    link: string;
-    icon: string;
-    entityType: string;
-    colorScheme: string;
-    videoUrl: string;
-    owners: string[] | UserType[];
-    createdBy: string  | UserType;
-    createdOn: Date;
-    updatedBy: string | UserType;
-    updatedOn: Date;
-    permissions: PermissionsType[];
+  name: string;
+  description: string;
+  link: string;
+  icon: string;
+  entityType: string;
+  colorScheme: string;
+  videoUrl: string;
+  owners: string[] | UserType[];
+  createdBy: string  | UserType;
+  createdOn: Date;
+  updatedBy: string | UserType;
+  updatedOn: Date;
+  permissions: PermissionsType[];
 }

--- a/packages/home-service/src/types.d.ts
+++ b/packages/home-service/src/types.d.ts
@@ -1,6 +1,10 @@
 declare module '*.graphql';
 declare module '*.json';
 
+type PermissionsType = {
+  roverGroup: string;
+  role: string;
+}
 type UserType = {
     name: string;
     title: string;
@@ -27,4 +31,5 @@ type HomeType = {
     createdOn: Date;
     updatedBy: string | UserType;
     updatedOn: Date;
+    permissions: PermissionsType[];
 }


### PR DESCRIPTION
fix(#360) - Added permissions array to the schema, type.d.ts and type def.graphql

# Closes/Fixes/Resolves

### Resolves #360 

# Explain the feature/fix

Added permissions array to the schema 

## Does this PR introduce a breaking change

No

## Screenshots

<img width="1680" alt="Screenshot 2020-06-01 at 6 15 34 PM" src="https://user-images.githubusercontent.com/12994292/83410373-e6c24480-a433-11ea-95d1-c5c894d09f05.png">

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?
