### PR TITLE
feat(#419) - Create getHomeTypeByUser API endpoint in home-service

### DIFF
--- a/packages/home-service/src/resolver.ts
+++ b/packages/home-service/src/resolver.ts
@@ -34,6 +34,16 @@ export const HomeResolver = {
         });
       })
       .catch(err => err);
+    },
+    getHomeTypeByUser(root: any, args: any, ctx: any) {
+      return Home.find({'owners': {'$in': [ args.rhuuid ]}}).lean()
+      .then( (response) => {
+        const builtQuery = `${HomeHelper.buildGqlQuery(response)}`;
+        return HomeHelper.getUserDetails(builtQuery).then((userDetails: any) => {
+          return HomeHelper.stitchHomeType(response, userDetails.data);
+        });
+      })
+      .catch(err => err);
     }
   },
   Mutation: {

--- a/packages/home-service/src/typedef.graphql
+++ b/packages/home-service/src/typedef.graphql
@@ -68,6 +68,8 @@ type Query {
   getHomeType(_id: String!): [HomeType]
   # Fetches HomeType by any property
   getHomeTypeBy(input: HomeInput): [HomeType]
+  # Fetches all HomeType for a user with rhuuid
+  getHomeTypeByUser(rhuuid: String!): [HomeType]
 }
 
 type Mutation {


### PR DESCRIPTION
### Resolves #419 

# Explain the feature/fix

Added getHomeTypeByUser API endpoint in graphql and resolver using mongo

## Does this PR introduce a breaking change

No

## Screenshots

<img width="1680" alt="Screenshot 2020-06-12 at 4 21 41 AM" src="https://user-images.githubusercontent.com/12994292/84447094-bca72880-ac64-11ea-81cc-4ea222a1a655.png">


### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
