### PR TITLE
fix(graphql-schema): Changed duplicate GraphQL types for User and Home

### DIFF
--- a/packages/feedback-service/src/typedef.graphql
+++ b/packages/feedback-service/src/typedef.graphql
@@ -1,6 +1,6 @@
 scalar DateTime
 
-type UserType {
+type FeedbackUserType {
   _id: String
   name: String
   title: String
@@ -16,9 +16,9 @@ type FeedbackWithUserType {
   experience: String
   spa: String
   createdOn: DateTime
-  createdBy: UserType
+  createdBy: FeedbackUserType
   updatedOn: DateTime
-  updatedBy: UserType
+  updatedBy: FeedbackUserType
   title: String
   feedbackType: String
 }

--- a/packages/home-service/src/helpers.ts
+++ b/packages/home-service/src/helpers.ts
@@ -16,7 +16,7 @@ export const pubsub = new RedisPubSub( {
 
 class HomeAPIHelper {
   userFragment = `
-        fragment user on UserType {
+        fragment user on HomeUserType {
             _id
             name
             title
@@ -67,7 +67,7 @@ class HomeAPIHelper {
       .then( ( res: any ) => res.json() );
   }
   /**
-   * Replaces the owners array(owners: string[]) with populated userType (owners: userType[])
+   * Replaces the owners array(owners: string[]) with populated HmoeUserType (owners: HomeUserType[])
    * @param response Database response
    * @param userDetails UserDetails which are fetched from user-service
    */

--- a/packages/home-service/src/typedef.graphql
+++ b/packages/home-service/src/typedef.graphql
@@ -8,7 +8,7 @@ type PermissionsType {
   roverGroup: String
   role: APIROLE
 }
-type UserType {
+type HomeUserType {
   _id: String
   name: String
   title: String
@@ -31,10 +31,10 @@ type HomeType {
   entityType: String
   colorScheme: String
   videoUrl: String
-  owners: [UserType]
-  createdBy: UserType
+  owners: [HomeUserType]
+  createdBy: HomeUserType
   createdOn: DateTime
-  updatedBy: UserType
+  updatedBy: HomeUserType
   updatedOn: DateTime
   active: Boolean
   permissions: [PermissionsType]

--- a/packages/home-service/src/types.d.ts
+++ b/packages/home-service/src/types.d.ts
@@ -8,20 +8,20 @@ declare enum Role {
 type PermissionsType = {
   roverGroup: string;
   role: Role;
-}
-type UserType = {
+};
+type HomeUserType = {
   name: string;
   title: string;
   uid: string;
   rhatUUID: string;
-  isActive ?: boolean;
+  isActive?: boolean;
   memberOf: string[];
   apiRole: string,
   createdBy: string;
   createdOn: Date;
   updatedBy: string;
   updatedOn: Date;
-  }
+};
 type HomeType = {
   name: string;
   description: string;
@@ -30,11 +30,11 @@ type HomeType = {
   entityType: string;
   colorScheme: string;
   videoUrl: string;
-  owners: string[] | UserType[];
-  createdBy: string  | UserType;
+  owners: string[] | HomeUserType[];
+  createdBy: string | HomeUserType;
   createdOn: Date;
-  updatedBy: string | UserType;
+  updatedBy: string | HomeUserType;
   updatedOn: Date;
   active: boolean;
   permissions: PermissionsType[];
-}
+};

--- a/packages/notifications-service/src/helpers.ts
+++ b/packages/notifications-service/src/helpers.ts
@@ -33,8 +33,8 @@ export const nodemailer = createTransport( {
 
 export const GqlHelper = {
   fragments: {
-    homeType: `on HomeType {
-      _id name link entityType owners { uid name }
+    homeType: /* GraphQL */`fragment homeType on HomeType {
+      _id name link icon entityType active owners { uid name }
     }`,
   },
   execSimpleQuery ( { queries, fragments }: GraphQLQueryInput ) {

--- a/packages/notifications-service/src/notificationConfig/resolver.ts
+++ b/packages/notifications-service/src/notificationConfig/resolver.ts
@@ -20,7 +20,7 @@ export const NotificationConfigResolver: any = {
               ];
             }, [] )
             .map( ( source, index ) => {
-              return `source_${ index }: getHomeTypeBy(input: { _id: "${ source }" }) { _id name link entityType owners { uid name } }`;
+              return `source_${ index }: getHomeTypeBy(input: { _id: "${ source }" }) { ...homeType }`;
             } );
 
           /* Executing the queries */

--- a/packages/notifications-service/src/notificationConfig/typedef.graphql
+++ b/packages/notifications-service/src/notificationConfig/typedef.graphql
@@ -64,18 +64,20 @@ input ScheduledandTriggerInput {
   action: String
 }
 
-type UserType {
+type NotificationOwner {
   _id: String
   uid: String
   name: String
 }
 
-type HomeType {
+type NotificationSource {
   _id: String
   name: String
   link: String
+  icon: String
+  active: String
   entityType: String
-  owners: [UserType]
+  owners: [NotificationOwner]
 }
 
 type NotificationConfig {
@@ -83,7 +85,7 @@ type NotificationConfig {
   configID: ID
   template: String
   defaultLink: String
-  source: HomeType
+  source: NotificationSource
   targets: [String]
   channel: NotificationChannelEnum
   type: NotificationTypeEnum

--- a/packages/notifications-service/src/typedef.graphql
+++ b/packages/notifications-service/src/typedef.graphql
@@ -34,10 +34,6 @@ enum NotificationStatusEnum {
   FAILED
 }
 
-type HomeType {
-  _id: String
-}
-
 type PushNotification {
   id: ID
   title: String

--- a/packages/notifications-service/src/types.d.ts
+++ b/packages/notifications-service/src/types.d.ts
@@ -1,12 +1,6 @@
 declare module "*.graphql";
 declare module "*.json";
 
-type UserType = {
-  name: string;
-  uid: string;
-  rhUUID: string;
-};
-
 declare enum NotificationChannel {
   EMAIL = 'EMAIL',
   PUSH = 'PUSH',

--- a/packages/user-service/src/typedef.graphql
+++ b/packages/user-service/src/typedef.graphql
@@ -97,7 +97,7 @@ input UserInput {
   updatedOn: DateTime
 }
 
-type Mutation  {
+type Mutation {
   # Add a new User
   addUser(input: UserInput): UserType
   # Update existing User
@@ -108,9 +108,14 @@ type Mutation  {
   addUserFromLDAP(uid: String!): UserType
 }
 
-type Query  {
+type Query {
   # Fetches specific User by uid, rhatUUID, apiRole, name
-  getUsersBy( uid: String, rhatUUID: String, apiRole: String, name: String): [UserType]
+  getUsersBy(
+    uid: String
+    rhatUUID: String
+    apiRole: String
+    name: String
+  ): [UserType]
   # Fetches all Users
   listUsers: [UserType]
   # Fetch LDAP Group Members


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "One Platform Developers"
Projects: "One Platform Development"
-->

### Fixes: ONEPLAT-398

# Explain the feature/fix

<!-- Provide a clear explaination of the feature/fix implemented -->
Renamed the duplicate graphql types for UserType and
HomeType defined in Notifications, Home and Feedback Microservices.


## Does this PR introduce a breaking change

<!-- Yes/No -->
Yes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->
N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
