### PR TITLE
fix: Using pull_request_target instead of pull_request to fix forked repo actions

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,12 +1,12 @@
 name: Notify the Gchat Group
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
     - name: Google Chat Notification
-      uses: CommonMarvel/google-chat-notification@v1.1.1
+      uses: gautamkrishnar/google-chat-notification@master
       with:
         url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}


### PR DESCRIPTION
Using pull_request_target instead of pull_request to fix forked repo actions