### PR TITLE
fix(#619) - Home-SPA illustration height breaking for smaller screens

### DIFF
--- a/packages/home-spa/src/styles/main.scss
+++ b/packages/home-spa/src/styles/main.scss
@@ -1,10 +1,10 @@
 @import './common.scss';
 
 .hero {
-    height: 90%;
+    height: 90vh;
     text-align: center;
     background-image: url('/img/illustration.svg');
-    background-position: center;
+    background-position: center top;
     background-repeat: no-repeat;
     overflow: auto;
     &__mantra {


### PR DESCRIPTION
### Resolves #619 

# Explain the feature/fix

Added background as center top and view height as 90

## Does this PR introduce a breaking change

No

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
