### PR TITLE
Bug/(#411):-Add margin top to feedback detail pop up

### DIFF
--- a/packages/feedback-spa/src/app/feedback/home/feedback-home.component.html
+++ b/packages/feedback-spa/src/app/feedback/home/feedback-home.component.html
@@ -58,7 +58,7 @@
   <button #fiModalTrigger hidden="true" aria-hidden="true" data-target="#feedback-details-modal" data-toggle="modal"
     aria-label="Show Details"></button>
   <div class="modal fade" id="feedback-details-modal" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
+    <div class="modal-dialog modal-lg mt-5">
       <div class="modal-content">
         <div class="modal-header">
           <a class="h5 text-dark" *ngIf="feedbackDetails?.ticketID"


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "One Platform Developers"
Projects: "One Platform Development"
-->

# Closes/Fixes/Resolves

### <!-- Any of the keywords: Closes/Fixes/Resolves followed by #issue_id (should be separated by a space only) -->

# Explain the feature/fix

<!-- Provide a clear explaination of the feature/fix implemented -->
Add top margin to feedback detail pop up(modal) so that it will not override notification drawer. 

## Does this PR introduce a breaking change

No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshots below this line -->

![image](https://user-images.githubusercontent.com/12980398/90753579-699dc180-e2f6-11ea-83cd-b2385d1fa706.png)


</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did tests pass?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
