### PR TITLE
chore(renovate): Group minors & patches together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,14 @@
   "packageRules": [
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "automerge": true,
+      "packagePatterns": [
+        "*"
+      ],
+      "minor": {
+        "groupName": "all non-major dependencies",
+        "groupSlug": "all-minor-patch"
+      }
     }
   ]
 }


### PR DESCRIPTION
Updated Renovate configuration to group all minors & patches together.