### PR TITLE
fix(ssi): CSS fallbacks for Safari and unsupported broswers

### DIFF
--- a/packages/ssi-service/src/nav/nav.css
+++ b/packages/ssi-service/src/nav/nav.css
@@ -67,17 +67,13 @@
 .op-search__btn {
   position: absolute;
   left: 0;
+  margin: 0;
   padding: 0.75rem;
   border-radius: 50%;
   background: none;
   border: none;
   box-sizing: border-box;
   cursor: pointer;
-}
-.op-search__icon {
-  width: 1rem;
-  height: 1rem;
-  display: block;
 }
 .op-search__btn:hover,
 .op-search__btn:focus {
@@ -86,7 +82,7 @@
 .op-search-bar__input {
   width: 100%;
   padding: 0.5rem;
-  padding-left: 2.5rem;
+  padding-left: 2.75rem;
   box-sizing: border-box;
   border: 1px solid transparent;
   background: #f5f5f5;
@@ -96,6 +92,8 @@
   font-size: inherit;
   outline: none;
   transition: all var(--op-transition--default);
+  /* WKRD: for Safari */
+  -webkit-appearance: none;
 }
 .op-search-bar__input:focus {
   box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.16);
@@ -195,10 +193,15 @@
   padding-top: 1rem;
   box-sizing: border-box;
   height: calc(100vh - var(--op-nav__height));
+  background: rgba(255,255,255,.95);
   box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.16);
   border: none;
   overflow-y: auto;
   z-index: 0;
+}
+.op-menu-drawer:not([open]) {
+  /* WKRD: if the user agent stylesheet does not support dialog elements */
+  display: none;
 }
 .op-menu-drawer[data-type="app"] {
   right: 0;
@@ -232,6 +235,7 @@
   background: white;
   font-size: 1.25rem;
   font-weight: 500;
+  z-index: 1;
 }
 .op-menu-drawer > p {
   margin-top: 0;


### PR DESCRIPTION
# Fixes 671, 598

# Explain the feature/fix

- Added some default CSS styles and fallbacks for the Menu Drawer and the search bar to extend support to browsers like Safari.
- Elevated the "Notifications" heading to make it float on top of the notifications in the notification drawer.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
