### PR TITLE
hotfix(ssi): Changed post-auth redirect to use replaceState

### DIFF
--- a/packages/ssi-service/src/auth.js
+++ b/packages/ssi-service/src/auth.js
@@ -112,7 +112,7 @@ class OpAuth {
    */
   _removeHashes () {
     if ( window.location.hash.startsWith( '#not-before-policy=0' ) ) {
-      history.pushState( "", document.title, window.location.pathname + window.location.search );
+      history.replaceState( "", document.title, window.location.pathname + window.location.search );
     }
   }
 }


### PR DESCRIPTION
# Explain the feature/fix

Replace the `history.pushState` to `history.replaceState` for the post-auth redirect.
It helps keep the browser history clean, and avoids navigation issues when navigating back to an old page, by skipping the intermediate auth callback url.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
