### PR TITLE
fix(user-groups-spa): Fixed useState looping in some edge cases

### DIFF
--- a/packages/user-group-spa/src/App.jsx
+++ b/packages/user-group-spa/src/App.jsx
@@ -24,7 +24,7 @@ function App ( props ) {
     setUser( {
       uid: authUser.kerberosID,
     } );
-  } );
+  }, [ ] );
 
   function isNavItemActive ( url ) {
     return location.pathname === url;

--- a/packages/user-group-spa/src/components/Home.jsx
+++ b/packages/user-group-spa/src/components/Home.jsx
@@ -59,7 +59,7 @@ function Home ( props ) {
         console.error( err );
         window.OpNotification.danger( { subject: 'There was some error fetching the list of groups' } );
       });
-  }, [props] );
+  }, [ ] );
 
   useEffect( () => {
     const searchQuery = RegExp( searchText, 'i' );


### PR DESCRIPTION
# Related 683

# Explain the feature/fix

The `useState` hook loops infinitely in some cases when the react app is deployed. So added a dependency to the `useState` to make sure it only runs once.

## Does this PR introduce a breaking change

No.


## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
