### PR TITLE
Fix: broken link for Research repo FAQs

### DIFF
--- a/packages/documentation-spa/docs/faqs.md
+++ b/packages/documentation-spa/docs/faqs.md
@@ -13,7 +13,7 @@ sidebar_label: One Platform FAQs
 
 ### Hosted Apps
 
-1. [Analyst Papers](/docs/apps/hosted/analyst-papers/analyst-papers-spa#faqs)
+1. [Research Repository](/docs/apps/hosted/research-repository/research-repository-spa#faqs)
 
 ### Internal Apps
 


### PR DESCRIPTION
# Closes/Fixes/Resolves

# Explain the feature/fix
Found a broken link for research repository FAQs

## Does this PR introduce a breaking change
No