### PR TITLE
fix(#732) - Citation (quotes) position needs to be fixed on the home page for firefox

### DIFF
--- a/packages/home-spa/src/styles/main.scss
+++ b/packages/home-spa/src/styles/main.scss
@@ -38,7 +38,7 @@
                 content: url('../img/begin-quote.svg');
                 position: absolute;
                 top: 30px;
-                right: -24px;
+                margin-left: .5rem;
                 transform: scaleX(-1);
             }
         }


### PR DESCRIPTION

### Resolves #732 

# Explain the feature/fix

Remove right and added a margin-left which fixed it for both firefox and chrome

## Does this PR introduce a breaking change

No

## Screenshots

<img width="1153" alt="Screenshot 2020-10-07 at 12 25 05 AM" src="https://user-images.githubusercontent.com/12994292/95247752-e39cf200-0833-11eb-8ea3-278c984195d6.png">


### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
