### PR TITLE
fix(ssi): SSI cleanup and style-loader fix

### DIFF
--- a/packages/ssi-service/package-lock.json
+++ b/packages/ssi-service/package-lock.json
@@ -16415,15 +16415,6 @@
         }
       }
     },
-    "to-string-loader": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/to-string-loader/-/to-string-loader-1.1.6.tgz",
-      "integrity": "sha512-VNg62//PS1WfNwrK3n7t6wtK5Vdtx/qeYLLEioW46VMlYUwAYT6wnfB+OwS2FMTCalIHu0tk79D3RXX8ttmZTQ==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.0.0"
-      }
-    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",

--- a/packages/ssi-service/package.json
+++ b/packages/ssi-service/package.json
@@ -50,7 +50,6 @@
     "html-webpack-plugin": "4.5.0",
     "jest": "26.5.3",
     "jest-environment-jsdom-sixteen": "1.0.3",
-    "to-string-loader": "1.1.6",
     "webpack": "5.1.3",
     "webpack-cli": "4.0.0",
     "webpack-dev-server": "3.11.0",

--- a/packages/ssi-service/public/index.html
+++ b/packages/ssi-service/public/index.html
@@ -21,8 +21,8 @@
     </style>
   </head>
   <body>
-    <h1>One Platform</h1>
-
     <!--#include virtual="/.include/nav/default.html" -->
+
+    <h1>One Platform</h1>
   </body>
 </html>

--- a/packages/ssi-service/src/auth.js
+++ b/packages/ssi-service/src/auth.js
@@ -13,7 +13,6 @@ class OpAuth {
     this.keycloakInitOptions = {
       onLoad: 'login-required',
       checkLoginIframe: false,
-      enableLogging: true,
     };
 
     this._keycloak = new Keycloak(this.keycloakOptions);

--- a/packages/ssi-service/src/default.html
+++ b/packages/ssi-service/src/default.html
@@ -61,15 +61,19 @@
 
   function main () {
     const dump = document.body.innerHTML;
-    document.body.innerHTML = '<div class="op-loader__container"><span class="op-loader">L &nbsp; ading</span></div>';
+    document.write('<div id="op-loader__global" class="op-loader__container"><span class="op-loader">L &nbsp; ading</span></div>');
 
     const styleTag = document.createElement( 'style' );
     styleTag.innerHTML = styles;
-    document.body.prepend(styleTag);
+    document.head.appendChild(styleTag);
 
     window.OpAuthHelper.init();
     window.OpAuthHelper.onLogin( () => {
-      document.body.innerHTML = dump;
+      const loader = document.getElementById('op-loader__global');
+      if (loader) {
+        loader.remove();
+      }
+      styleTag.remove();
       document.body.prepend( opfNav );
       document.body.append( opfFeedback );
     } );

--- a/packages/ssi-service/src/feedback-panel/feedback.js
+++ b/packages/ssi-service/src/feedback-panel/feedback.js
@@ -14,7 +14,7 @@ window.customElements.define( 'op-feedback', class extends HTMLElement {
       this.shadowRoot.appendChild( this._template.content.cloneNode( true ) );
 
       const styleTag = document.createElement( 'style' );
-      styleTag.innerText = styles;
+      styleTag.innerHTML = styles.toString();
       this.shadowRoot.prepend( styleTag );
 
       this.feedbackButton = this.shadowRoot.querySelector( '#op-feedback__button' );

--- a/packages/ssi-service/src/nav/nav.css
+++ b/packages/ssi-service/src/nav/nav.css
@@ -56,8 +56,7 @@
 .op-search {
   flex: 1 0 auto;
   max-width: 720px;
-  margin-left: 0.5rem;
-  margin-right: 1rem;
+  margin: 0 1rem 0 .5rem;
   font-size: 1rem;
 
   display: flex;

--- a/packages/ssi-service/src/nav/nav.js
+++ b/packages/ssi-service/src/nav/nav.js
@@ -19,7 +19,7 @@ window.customElements.define( 'op-nav', class extends LitElement {
     };
   }
   static get styles () {
-    return css`${ unsafeCSS( styles ) }`;
+    return css`${ unsafeCSS( styles.toString() ) }`;
   }
 
   constructor () {

--- a/packages/ssi-service/webpack.config.js
+++ b/packages/ssi-service/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = ( _, { mode } ) => {
         },
         {
           test: /\.css$/i,
-          use: [ 'to-string-loader', 'css-loader' ]
+          use: [ 'css-loader' ]
         }
       ]
     },


### PR DESCRIPTION
# Fixes
Style load issues in the SSI nav and feedback-panel components

# Explain the feature/fix

The to-string-loader caused some problems and was returning a `[object Module]` instead of the actual css contents.\
So removed it in favour of `.toString()`

Also, updated the default.html so the loader is added and removed from the DOM much more cleanly.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
