### PR TITLE
fix(user-group-service): Fixes user-group-service build error for _id type

### DIFF
--- a/packages/user-group-service/src/types.d.ts
+++ b/packages/user-group-service/src/types.d.ts
@@ -65,7 +65,7 @@ type LdapType = {
 }
 
 type User = {
-  _id: any;
+  _id?: any;
   name: string;
   title: string;
   uid: string;
@@ -80,7 +80,7 @@ type User = {
 }
 
 type Group = {
-  _id: any;
+  _id?: any;
   name: string;
   ldapCommonName: string;
   createdOn: Date;
@@ -88,7 +88,7 @@ type Group = {
 }
 
 type APIKey = {
-  _id: any;
+  _id?: any;
   accessToken: string;
   shortKey: string;
   hashKey: string;


### PR DESCRIPTION
# Fixes User Group Microservice Build errors

# Explain the feature/fix

Due to recent updates in the mongoose type definitions, the build broke for User Group with as error for _id type mismatch.
Making the field optional fixes it.

## Does this PR introduce a breaking change

No

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
