### PR TITLE
fix(notifications-service): Hard locked mongoose to v5.10.8

### DIFF
--- a/packages/notifications-service/package-lock.json
+++ b/packages/notifications-service/package-lock.json
@@ -9489,9 +9489,9 @@
       }
     },
     "mongoose": {
-      "version": "5.11.9",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.11.9.tgz",
-      "integrity": "sha512-lmG6R64jtGGxqtn88BkkY+v470LUfGgyTKUyjswQ5c01GNgQvxA0kQd8h+tm0hZb639hKNRxL9ZBQlLleUpuIQ==",
+      "version": "5.11.8",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.11.8.tgz",
+      "integrity": "sha512-RRfrYLg7pyuyx7xu5hwadjIZZJB9W2jqIMkL1CkTmk/uOCX3MX2tl4BVIi2rJUtgMNwn6dy3wBD3soB8I9Nlog==",
       "requires": {
         "@types/mongodb": "^3.5.27",
         "bson": "^1.1.4",

--- a/packages/notifications-service/package.json
+++ b/packages/notifications-service/package.json
@@ -58,7 +58,7 @@
     "lodash": "4.17.20",
     "method-override": "3.0.0",
     "moment": "2.29.1",
-    "mongoose": "5.11.9",
+    "mongoose": "5.11.8",
     "node-fetch": "2.6.1",
     "nodemailer": "6.4.17",
     "nodemon-webpack-plugin": "4.3.2",


### PR DESCRIPTION
# Fixes build issues for notifications-service

# Explain the feature/fix

There are some breaking changes in ^5.10.9
which cause the build to fail with some lint errors

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?