### PR TITLE
chore: remove codeql scanning for PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,6 @@ name: "CodeQL"
 on:
   push:
     branches: [master]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
   schedule:
     - cron: '0 18 * * 5'
 


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "One Platform Developers"
Projects: "One Platform Development"
-->

# Closes/Fixes/Resolves
n.a

# Explain the feature/fix
<img width="1051" alt="Screenshot 2021-01-19 at 6 04 37 PM" src="https://user-images.githubusercontent.com/8397274/105035478-11274780-5a81-11eb-827b-0fa4ca2c63da.png">

CodeQL scanning is required only on merge commits, not on every PR. Removing the PR trigger. https://github.com/1-Platform/one-platform/pull/861/checks?check_run_id=1727515955#step:4:1 is an example of this recommendation.

## Does this PR introduce a breaking change
No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Screenshots
n/a

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
