### PR TITLE
fix(api-gateway): Removes case sensitivity from authorization header

### DIFF
--- a/packages/api-gateway-service/service.ts
+++ b/packages/api-gateway-service/service.ts
@@ -29,7 +29,7 @@ const context = ({ req, connection }: any) => {
     throw new AuthenticationError( 'Auth Token Missing' );
   }
 
-  if ( !authorizationHeader.startsWith( 'Bearer' ) ) {
+  if ( !authorizationHeader.toLowerCase().startsWith( 'bearer' ) ) {
     throw new AuthenticationError( 'Only Bearer tokens are supported' );
   }
 


### PR DESCRIPTION
# Resolves
Case sensitivity error for "Bearer" in authorization header.

# Explain the feature/fix

Although there's no apparent standard for the case in the Authorization header value, title case is used generally, but wanted to make it case insensitive so it would work even for non-standard implementations.

## Does this PR introduce a breaking change

No.

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
- [x] Was this feature demo'd and the design review approved?
