### PR TITLE
fix(404-page): Adds htaccess for 404 page (in the home-spa)

### DIFF
--- a/packages/home-spa/.htaccess
+++ b/packages/home-spa/.htaccess
@@ -1,0 +1,5 @@
+Options +SymLinksIfOwnerMatch
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . 404.html [L]

--- a/packages/home-spa/src/404.html
+++ b/packages/home-spa/src/404.html
@@ -16,7 +16,7 @@
     <!-- 404-banner Start -->
     <div class="banner">
       <div class="banner__404">
-        <img src="img/404.svg" alt="404">
+        <img src="/img/404.svg" alt="404">
       </div>
       <div class="banner__text-block--medium">
         <h1>Whoops! There is nothing here</h1>

--- a/packages/home-spa/src/index.html
+++ b/packages/home-spa/src/index.html
@@ -64,14 +64,14 @@
 						Blogs
 					</h3>
 					<div class="documentation-modal__blog-content">
-						<img src="img/blog_illustration.png" alt="BLogs">
+						<img src="/img/blog_illustration.png" alt="BLogs">
 						<div class="documentation-modal__blog-list" id="blog-list">
 						</div>
 					</div>
 				</div>
 				<div class="documentation-modal__link">
 					<div class="documentation-modal__link-microservice">
-						<img src="img/microservices_illustration.png" alt="microservices">
+						<img src="/img/microservices_illustration.png" alt="microservices">
 						<a href="/get-started">
 							<h3>Microservice</h3>
 							<p>
@@ -80,7 +80,7 @@
 						</a>
 					</div>
 					<div class="documentation-modal__link-components">
-						<img src="img/components_illustration.png" alt="components">
+						<img src="/img/components_illustration.png" alt="components">
 						<a href="/components">
 							<h3>Component Library</h3>
 							<p>
@@ -90,7 +90,7 @@
 					</div>
 				</div>
 				<div class="documentation-modal__faqs">
-					<img src="img/faq_illustration.png" alt="faqs">
+					<img src="/img/faq_illustration.png" alt="faqs">
 					<a href="/get-started/docs/faqs">
 						<h3> Frequently asked questions</h3>
 						<p>

--- a/packages/home-spa/webpack.config.js
+++ b/packages/home-spa/webpack.config.js
@@ -75,6 +75,7 @@ module.exports = {
             patterns: [
                 { from: 'img/**', context: 'src' },
                 'favicon.ico',
+                '.htaccess'
             ],
         }),
         new HtmlWebpackPlugin({


### PR DESCRIPTION
# Fixes ONEPLAT-388

# Explain the feature/fix

- Adds a .htaccess file to the home-spa to handle 404 errors by returning the 404.html page instead
- And also replaces relative img paths to absolute especially in 404.html page

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
