### PR TITLE
fix(#928) - 404 page ui breaks on stage and prod due to > 8 apps being displayed in the same row

### DIFF
--- a/packages/home-spa/src/js/controller.js
+++ b/packages/home-spa/src/js/controller.js
@@ -99,7 +99,7 @@ function buildDom(apiData) {
           return `<a href="${spa.link}"><em class="fa ${spa.icon}"></em>${spa.name}</a>`;
         }
       }
-    ).join('');
+    ).splice(0,10).join('');
   }
 
   if (apps !== null) {

--- a/packages/home-spa/src/styles/main.scss
+++ b/packages/home-spa/src/styles/main.scss
@@ -229,6 +229,7 @@
     &__links {
         list-style: none;
         display: flex;
+        flex-wrap: wrap;
         justify-content: center;
         font-size: 20px;
         a {


### PR DESCRIPTION
## Closes/Fixes/Resolves

### Resolves #928 

## Explain the feature/fix

Limited the number of links to 10 and also added a flex-wrap

## Does this PR introduce a breaking change

No

# Screenshots

## With just flex-wrap
![Screenshot 2021-04-19 at 2 48 43 PM](https://user-images.githubusercontent.com/12994292/115212916-a1c40100-a11e-11eb-9ceb-77133168b379.png)



## With flex-wrap and limit upto 10


![Screenshot 2021-04-19 at 2 49 32 PM](https://user-images.githubusercontent.com/12994292/115212935-a8527880-a11e-11eb-8165-23793bac24ef.png)

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
