### PR TITLE
fix(api-gateway-subscriptions): Defines explicit path for subscriptions url

### DIFF
--- a/packages/api-gateway-service/service.ts
+++ b/packages/api-gateway-service/service.ts
@@ -64,6 +64,9 @@ stitchedSchemas()
         path: error.path,
         ...error.extensions,
       } ),
+      subscriptions: {
+        path: '/subscriptions',
+      },
       playground: <any>{
         title: 'API Gateway',
         settings: {


### PR DESCRIPTION
# Fixes

Invalid subscriptions endpoint error on API Gateway

# Explain the feature/fix

The subscriptions path was not explicitly configured in the Apollo Server constructor. Not sure how this got affected, as the default should be `/subscriptions`, but the playground was trying to use `/graphql` instead of `/subscriptions`

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
