### PR TITLE
fix(#959) - Add a search microservice guide for One Platform in doc SPA

### DIFF
--- a/packages/documentation-spa/docs/microservices/search/search-service.md
+++ b/packages/documentation-spa/docs/microservices/search/search-service.md
@@ -3,8 +3,6 @@ id: search-service
 title: Search Service
 sidebar_label: Search Service
 ---
-***
-# Search Service
 
 ## Developers
 

--- a/packages/documentation-spa/docs/microservices/search/search-service.md
+++ b/packages/documentation-spa/docs/microservices/search/search-service.md
@@ -1,0 +1,162 @@
+---
+id: search-service
+title: Search Service
+sidebar_label: Search Service
+---
+***
+# Search Service
+
+## Developers
+
+## Component Contributors
+
+1. Rigin Oommen - [roommen@redhat.com](mailto:roommen@redhat.com) - [riginoommen (Rigin Oommen) · GitHub](https://github.com/riginoommen)
+
+## Getting Started
+
+Search Microservice is a pillar which talks to Hydra APIs integrated with solr instances. This microservice is used to manage the search index
+
+## Usage
+
+### Introduction
+
+Search microservice is built using NodeJS which has hydra API support. This microservice serves as the index store for the one platform. Most of the SPAs and microservices uses this data to implement search functionality.
+
+### Supported Features
+
+1. Create Search Index
+2. Update Search Index
+3. Delete Search Index
+4. Read Search Index
+
+#### Apps using this microservice
+
+* All Native and Non native SPAs
+
+### Quick Start Guide
+
+#### Prerequisites
+
+1. **NodeJS** should be installed (_version\&gt;=__v10.15.3_)
+2. **NPM** should be installed _(version\&gt;= __6.4.1__ )_
+3. Version control system required. Preferably **git**.
+
+#### Steps
+
+1. Clone the [repository](https://github.com/1-Platform/one-platform).
+
+```sh
+git clone git@github.com:1-Platform/one-platform.git
+```
+
+2. Switch the working directory to the user microservice
+
+```sh
+cd one-platform/packages/search-service
+```
+
+3. Install the microservice dependencies.
+
+```sh
+npm i
+```
+
+### Start
+
+1. Run npm start:dev to run your microservice for dev env and npm start for production env.
+2. Navigate to port 8080 to see the microservice.
+
+eg: http://localhost:8080/graphql
+
+### Build
+
+1. [Webpack](https://webpack.js.org/) is used for the build system in the microservices.
+2. Run npm build:dev to generate a build for dev env and npm build for production build.
+
+### Testing
+
+1. For testing microservice with [supertest](https://www.npmjs.com/package/supertest) with the preconfigured settings.
+2. Test related environment configurations are present in .test.env under the e2e folder.
+3. Execute the command for testing.
+
+```sh
+npm run test
+```
+
+### API References
+
+In the GraphQL GET Operations are defined as Queries and POST/PUT/PATCH operations are defined as Mutations.
+
+## Queries
+
+### Search Query
+
+- Operation Name - search
+    - Supported Query Variables - query, start, rows
+
+Example Query
+```graphql
+query Search($query: String, $start: Int, $rows: Int) {
+    search(query: $query, $start: 10: $rows: 10) {
+        responseHeader{
+            status
+            }
+    response {
+        numFound
+        docs {
+            id
+            title
+            abstract
+            description
+            icon
+            uri
+            tags
+            timestamp
+        }
+    }
+}
+```
+## Mutations
+
+In search microservice every record has a unique key called id which is used to manage the mutation.
+
+1. Add/Update new index
+
+### Operation Name - manageIndex
+
+- Required Mutation Variables - SearchInput
+
+Example Mutation
+```graphql
+mutation ManageIndex($input: SearchInput) {
+    manageIndex(input: $input) {
+        response {
+            docs: [{
+                id
+                title
+                abstract
+                description
+                icon
+                uri
+                tags
+                timestamp
+            }]
+        }
+    }
+}
+```
+### Delete from index
+
+- Operation Name - deleteIndex
+
+    - Required Mutation Variables - name, title, uid, rhatUUID, memberOf, createdBy, createdOn, updatedBy, updatedOn
+
+Example Mutation
+
+```graphql
+mutation DeleteIndex($id: String!) {
+    deleteIndex(id:$id) {
+        status
+    }
+}
+```

--- a/packages/documentation-spa/sidebars.js
+++ b/packages/documentation-spa/sidebars.js
@@ -33,6 +33,7 @@ module.exports = {
         ]
       },
       'microservices/user-groups/user-groups-service',
+      'microservices/search/search-service',
     ],
     FAQs: [ 'faqs' ],
   },


### PR DESCRIPTION

## Resolves #959 

# Explain the feature/fix

- Added search microservice documentation to Doc-SPA and correct-ID

## Does this PR introduce a breaking change

No

## Screenshots

<img width="1676" alt="Screenshot 2021-05-25 at 11 14 38 PM" src="https://user-images.githubusercontent.com/12994292/119544058-fd814a00-bdae-11eb-882e-4e93e0177a46.png">

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?
