### PR TITLE
fix(apps-service): Fixes updateApp mutation to return updated details

### DIFF
--- a/packages/apps-service/src/modules/apps/resolver.ts
+++ b/packages/apps-service/src/modules/apps/resolver.ts
@@ -38,7 +38,7 @@ export default <IResolvers<App, IAppsContext>>{
         ...app,
         updatedBy: ctx.rhatUUID,
         updatedOn: new Date(),
-      } ).exec();
+      }, { new: true } ).exec();
     },
     deleteApp: ( parent, { id }, ctx ) => {
       if ( !Apps.isAuthorized( id, ctx.rhatUUID ) ) {


### PR DESCRIPTION
# Fixes

ONEPLAT-1108

# Explain the feature/fix

The `updateApp` mutation returns the old data before the app was updated. Had to add a `{ new: true }` to the `findByIdAndUpdate` method.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
