### PR TITLE
fix(apps-service): Fixes myApps query and adds resolvers for service

### DIFF
--- a/packages/apps-service/src/@types/apps/index.d.ts
+++ b/packages/apps-service/src/@types/apps/index.d.ts
@@ -1,4 +1,5 @@
 type App = {
+  appId: string
   isActive: boolean
   name: string
   description: string
@@ -7,7 +8,7 @@ type App = {
   entityType: App.EntityType
   colorScheme: string
   videoUrl: string
-  owner: string
+  ownerId: string
   applicationType: App.Type
   contacts: {
     developers: Array<string>

--- a/packages/apps-service/src/@types/microservices/index.d.ts
+++ b/packages/apps-service/src/@types/microservices/index.d.ts
@@ -1,0 +1,30 @@
+type Microservice = {
+  serviceId: string
+  name: string
+  description: string
+  isActive: boolean
+  docsUrl: string
+  ownerId: string
+  permissions: [Microservice.Permissions]
+  serviceType: Microservice.Type
+  createdBy: string
+  createdOn: Date
+  updatedBy: string
+  updatedOn: Date
+}
+
+namespace Microservice {
+  type Permissions = {
+    refId: string
+    refType: PermissionsRefTypeEnum
+    role: string
+  }
+  declare const enum PermissionsRefTypeEnum {
+    User = 'User',
+    Group = 'Group'
+  }
+  declare const enum Type {
+    BUILTIN = 'BUILTIN',
+    HOSTED = 'HOSTED',
+  }
+}

--- a/packages/apps-service/src/index.ts
+++ b/packages/apps-service/src/index.ts
@@ -1,8 +1,9 @@
 import { ApolloServer, mergeSchemas } from 'apollo-server';
-import setupDatabase from './setup/database';
+import setupDatabase, {mongoose} from './setup/database';
 import { PORT } from './setup/env';
 import { CommonSchema } from './modules/common';
 import { AppsResolver, AppsSchema } from './modules/apps';
+import { MicroservicesResolver, MicroservicesSchema } from './modules/microservices';
 
 ( async () => {
   /* Initialize database connection */
@@ -18,9 +19,11 @@ import { AppsResolver, AppsSchema } from './modules/apps';
       schemas: [
         CommonSchema,
         AppsSchema,
+        MicroservicesSchema,
       ],
       resolvers: [
         AppsResolver,
+        MicroservicesResolver,
       ]
     } ),
     plugins: [

--- a/packages/apps-service/src/modules/apps/model.ts
+++ b/packages/apps-service/src/modules/apps/model.ts
@@ -2,23 +2,33 @@
 
 import { Document, Model, model, Schema } from 'mongoose';
 import { Apps } from '.';
+import uniqueIdFromPath from '../../utils/unique-id-from-path';
 
 export interface AppModel extends Document, App { }
 
 interface AppModelStatic extends Model<AppModel> {
-  isAuthorized( id: any, userId: string ): Promise<boolean>;
+  isAuthorized( appId: any, userId: string ): Promise<boolean>;
 }
 
 const AppSchema = new Schema<AppModel, AppModelStatic>( {
+  appId: {
+    type: String,
+    unique: true,
+    default: function ( this: App ) { return uniqueIdFromPath( this.path ); }
+  },
   isActive: { type: Boolean, default: false, },
   name: { type: String, unique: true, },
   description: { type: String, },
   path: { type: String, required: true, },
   icon: { type: String, },
-  entityType: { type: String, },
   colorScheme: { type: String, },
   videoUrl: { type: String, },
-  owners: { type: [ String ], },
+  ownerId: { type: String, },
+  permissions: [ {
+    refId: { type: String, },
+    refType: { type: String, enum: [ 'User', 'Group' ] },
+    role: { type: String, required: true, },
+  } ],
   applicationType: {
     type: String,
     enum: [ 'BUILTIN', 'HOSTED' ],
@@ -30,15 +40,6 @@ const AppSchema = new Schema<AppModel, AppModelStatic>( {
     qe: { type: [ String ], },
     stakeholders: { type: [String], },
   },
-  access: [ {
-    roverGroup: { type: String, },
-    role: {
-      type: String,
-      enum: [ 'EDIT', 'VIEW' ],
-      default: App.AccessRole.VIEW,
-      required: true,
-    },
-  } ],
   feedback: {
     isEnabled: { type: Boolean, default: false, },
     sourceType: {
@@ -66,9 +67,8 @@ const AppSchema = new Schema<AppModel, AppModelStatic>( {
   updatedOn: { type: Date, default: Date.now },
 } );
 
-AppSchema.static( 'isAuthorized', async ( id: any, owner: string ) => {
-  const app = await Apps.findById( id ).exec();
-  return app && owner && app.owner === owner;
+AppSchema.static( 'isAuthorized', ( appId: any, userId: string ) => {
+  return Apps.exists( { _id: appId, ownerId: userId } );
 } );
 
 export default model<AppModel, AppModelStatic>( 'App', AppSchema );

--- a/packages/apps-service/src/modules/apps/schema.gql.ts
+++ b/packages/apps-service/src/modules/apps/schema.gql.ts
@@ -4,7 +4,8 @@ export default /* GraphQL */`
 type Query {
   apps: [App]
   myApps: [App]
-  app(selectors: FindAppInput!): [App]
+  findApps(selectors: FindAppInput!): [App]
+  app(appId: String!): App
 }
 type Mutation {
   createApp(app: CreateAppInput!): App
@@ -14,6 +15,7 @@ type Mutation {
 
 type App {
   id: ID
+  appId: String
   isActive: Boolean
   name: String
   description: String
@@ -22,7 +24,7 @@ type App {
   entityType: AppEntityType
   colorScheme: String
   videoUrl: String
-  owner: String
+  ownerId: String
   applicationType: AppType
   contacts: AppContacts
   access: [AppAccess]
@@ -36,10 +38,11 @@ type App {
 }
 input FindAppInput {
   id: ID
+  appId: String
   name: String
   path: String
   entityType: AppEntityType
-  owner: String
+  ownerId: String
   applicationType: AppType
   createdBy: String
   updatedBy: String
@@ -69,7 +72,7 @@ input UpdateAppInput {
   entityType: AppEntityType
   colorScheme: String
   videoUrl: String
-  owner: String
+  ownerId: String
   applicationType: AppType
   contacts: AppContactsInput
   access: [AppAccessInput]

--- a/packages/apps-service/src/modules/microservices/index.ts
+++ b/packages/apps-service/src/modules/microservices/index.ts
@@ -1,0 +1,7 @@
+import schema from './schema.gql';
+import resolver from './resolver';
+import model from './model';
+
+export const MicroservicesSchema = schema;
+export const MicroservicesResolver = resolver;
+export const Microservices = model;

--- a/packages/apps-service/src/modules/microservices/model.ts
+++ b/packages/apps-service/src/modules/microservices/model.ts
@@ -1,0 +1,43 @@
+import { Document, model, Model, Schema } from 'mongoose';
+import { Microservices } from '.';
+import uniqueIdFromPath from '../../utils/unique-id-from-path';
+
+export interface MicroserviceModel extends Microservice, Document { }
+
+interface MicroserviceModelStatic extends Model<MicroserviceModel> {
+  isAuthorized ( microserviceId: any, userId: string ): Promise<boolean>;
+}
+
+const MicroserviceSchema = new Schema<MicroserviceModel, MicroserviceModelStatic>( {
+  serviceId: {
+    type: String,
+    unique: true,
+    default: function ( this: Microservice ) { return uniqueIdFromPath( this.name ); },
+  },
+  name: { type: String, unique: true, },
+  description: { type: String, },
+  isActive: { type: Boolean, default: false, },
+  docsUrl: { type: String, },
+  ownerId: { type: String, },
+  permissions: [ {
+    refId: { type: String, },
+    refType: { type: String, enum: [ 'User', 'Group' ] },
+    role: { type: String, required: true, },
+  } ],
+  serviceType: {
+    type: String,
+    enum: [ 'BUILTIN', 'HOSTED' ],
+    default: App.Type.HOSTED,
+    required: true,
+  },
+  createdBy: { type: String, },
+  createdOn: { type: Date, default: Date.now, },
+  updatedBy: { type: String, },
+  updatedOn: { type: Date, default: Date.now, },
+} );
+
+MicroserviceSchema.static( 'isAuthorized', ( microserviceId: any, userId: string ) => {
+  return Microservices.exists( { _id: microserviceId, ownerId: userId } );
+} );
+
+export default model<MicroserviceModel, MicroserviceModelStatic>( 'Micorservice', MicroserviceSchema );

--- a/packages/apps-service/src/modules/microservices/resolver.ts
+++ b/packages/apps-service/src/modules/microservices/resolver.ts
@@ -1,0 +1,57 @@
+/* GraphQL Resolver implementation */
+
+import { IResolvers } from 'apollo-server';
+import { Microservices } from '.';
+import uniqueIdFromPath from '../../utils/unique-id-from-path';
+
+export default <IResolvers<Microservice, IAppsContext>>{
+  Query: {
+    services: () => {
+      return Microservices.find().exec();
+    },
+    myServices: ( parent, args, { rhatUUID } ) => {
+      if ( !rhatUUID ) {
+        throw new Error( 'Cannot fetch myServices. Unauthenticated request.' );
+      }
+      return Microservices.find( { ownerId: rhatUUID } ).exec();
+    },
+    findServices: ( parent, { selectors }, ctx ) => {
+      return Microservices.find( selectors ).exec();
+    },
+    service: ( parent, { serviceId }, { rhatUUID } ) => {
+      return Microservices.findOne( { serviceId } ).exec();
+    },
+  },
+  Mutation: {
+    createService: ( parent, { service }, { rhatUUID } ) => {
+      if ( !rhatUUID ) {
+        throw new Error( 'Cannot create new service. Unauthenticated request.' );
+      }
+      return new Microservices( {
+        ...service,
+        ownerId: rhatUUID,
+        createdBy: rhatUUID,
+        updatedBy: rhatUUID,
+      } ).save();
+    },
+    updateService: ( parent, { id, service }, { rhatUUID } ) => {
+      if ( !Microservices.isAuthorized( id, rhatUUID ) ) {
+        throw new Error( 'User not authorized to update the service' );
+      }
+      if ( service.name ) {
+        service.serviceId = uniqueIdFromPath( service.name );
+      }
+      return Microservices.findByIdAndUpdate( id, {
+        ...service,
+        updatedBy: rhatUUID,
+        updatedOn: new Date(),
+      }, { new: true } ).exec();
+    },
+    deleteService: ( parent, { id }, { rhatUUID } ) => {
+      if ( !Microservices.isAuthorized( id, rhatUUID ) ) {
+        throw new Error( 'User not authorized to delete the service' );
+      }
+      return Microservices.findByIdAndRemove( id ).exec();
+    },
+  },
+}

--- a/packages/apps-service/src/modules/microservices/schema.gql.ts
+++ b/packages/apps-service/src/modules/microservices/schema.gql.ts
@@ -1,0 +1,76 @@
+/* GraphQL Schema Definition */
+
+export default /* GraphQL */`
+type Query {
+  services: [Service]
+  myServices: [Service]
+  findServices(selectors: FindServicesInput!): [Service]
+  service(serviceId: String!): Service
+}
+
+type Mutation {
+  createService(service: CreateServiceInput!): Service
+  updateService(id: ID!, service: UpdateServiceInput!): Service
+  deleteService(id: ID!): Service
+}
+
+type Service {
+  id: ID
+  serviceId: String
+  name: String
+  description: String
+  isActive: Boolean
+  docsUrl: String
+  ownerId: String
+  permissions: [AppPermissions]
+  serviceType: ServiceType
+  createdBy: String
+  createdOn: ISODate
+  updatedBy: String
+  updatedOn: ISODate
+}
+type AppPermissions {
+  refId: String
+  refType: AppPermissionRefType
+  role: String
+}
+
+input FindServicesInput {
+  serviceId: String
+  name: String
+  isActive: Boolean
+  ownerId: String
+  serviceType: ServiceType
+}
+input CreateServiceInput {
+  name: String!
+  description: String!
+  isActive: Boolean
+  docsUrl: String
+  permissions: [AppPermissionsInput]
+  serviceType: ServiceType!
+}
+input UpdateServiceInput {
+  name: String
+  description: String
+  isActive: Boolean
+  docsUrl: String
+  ownerId: String
+  permissions: [AppPermissionsInput]
+  serviceType: ServiceType
+}
+input AppPermissionsInput {
+  refId: String
+  refType: AppPermissionRefType
+  role: String
+}
+
+enum ServiceType {
+  BUILTIN
+  HOSTED
+}
+enum AppPermissionRefType {
+  User
+  Group
+}
+`;

--- a/packages/apps-service/src/utils/unique-id-from-path.ts
+++ b/packages/apps-service/src/utils/unique-id-from-path.ts
@@ -1,0 +1,9 @@
+export default function uniqueIdFromPath ( path: string ) {
+  return path.toLowerCase()
+    /* Replace any special characters with `-` */
+    .replace( /[\ \-\/\:\@\[\]\`\{\~\.]+/g, '-' )
+    /* Remove any starting or ending `-` */
+    .replace( /^-+|-+$/g, '' )
+    /* Removing multiple consecutive `-`s */
+    .replace( /--+/g, '-' );
+}


### PR DESCRIPTION
# Fixes

The `myApps` query returned an empty array due to a misconfigured schema.

# Explain the feature/fix

- Fixes myApps query and adds resolvers for service
- Refactored Apps resolvers to include `appId`, and cleanup the permissions field
- Adds queries and mutations for Services

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
