### PR TITLE
feat(apps-service): Additional fields to the app service, and a fix for the appId

### DIFF
--- a/packages/apps-service/src/modules/apps/model.ts
+++ b/packages/apps-service/src/modules/apps/model.ts
@@ -14,7 +14,7 @@ const AppSchema = new Schema<AppModel, AppModelStatic>( {
   appId: {
     type: String,
     unique: true,
-    default: function ( this: App ) { return uniqueIdFromPath( this.path ); }
+    default: function ( this: App ) { return uniqueIdFromPath( this.path ) || uniqueIdFromPath( this.name ); },
   },
   isActive: { type: Boolean, default: false, },
   name: { type: String, unique: true, },
@@ -60,6 +60,14 @@ const AppSchema = new Schema<AppModel, AppModelStatic>( {
   },
   notifications: {
     isEnabled: { type: Boolean, default: false, },
+  },
+  database: {
+    isEnabled: { type: Boolean, default: false, },
+  },
+  lighthouse: {
+    isEnabled: { type: Boolean, default: false, },
+    projectId: { type: String, },
+    branch: { type: String, },
   },
   createdBy: { type: String, },
   createdOn: { type: Date, default: Date.now, },

--- a/packages/apps-service/src/modules/apps/resolver.ts
+++ b/packages/apps-service/src/modules/apps/resolver.ts
@@ -9,11 +9,11 @@ export default <IResolvers<App, IAppsContext>>{
     apps: ( parent, args, ctx, info ) => {
       return Apps.find().exec();
     },
-    myApps: ( parent, args, ctx ) => {
-      if ( !ctx.rhatUUID ) {
-        throw new Error( 'User unauthorized to view my apps' );
+    myApps: ( parent, args, { rhatUUID } ) => {
+      if ( !rhatUUID ) {
+        throw new Error( 'Anonymous user unauthorized to view my apps' );
       }
-      return Apps.find({ ownerId: ctx.rhatUUID }).exec();
+      return Apps.find({ ownerId: rhatUUID }).exec();
     },
     findApps: ( parent, { selectors }, ctx ) => {
       return Apps.find( selectors ).exec();
@@ -25,7 +25,7 @@ export default <IResolvers<App, IAppsContext>>{
   Mutation: {
     createApp: ( parent, { app }, ctx ) => {
       if ( !ctx.rhatUUID ) {
-        throw new Error( 'User unauthorized to create new app' );
+        throw new Error( 'Anonymous user unauthorized to create new app' );
       }
       return new Apps( {
         ...app,

--- a/packages/apps-service/src/modules/apps/schema.gql.ts
+++ b/packages/apps-service/src/modules/apps/schema.gql.ts
@@ -21,13 +21,12 @@ type App {
   description: String
   path: String
   icon: String
-  entityType: AppEntityType
   colorScheme: String
   videoUrl: String
   ownerId: String
   applicationType: AppType
   contacts: AppContacts
-  access: [AppAccess]
+  permissions: [AppPermissions]
   feedback: AppFeedbackConfig
   search: AppMicroserviceConfig
   notifications: AppMicroserviceConfig
@@ -41,7 +40,6 @@ input FindAppInput {
   appId: String
   name: String
   path: String
-  entityType: AppEntityType
   ownerId: String
   applicationType: AppType
   createdBy: String
@@ -53,12 +51,11 @@ input CreateAppInput {
   description: String
   path: String!
   icon: String
-  entityType: AppEntityType
   colorScheme: String
   videoUrl: String
   applicationType: AppType
   contacts: AppContactsInput
-  access: [AppAccessInput]
+  permissions: [AppPermissionsInput]
   feedback: AppFeedbackConfigInput
   search: AppMicroserviceConfigInput
   notifications: AppMicroserviceConfigInput
@@ -69,20 +66,15 @@ input UpdateAppInput {
   description: String
   path: String
   icon: String
-  entityType: AppEntityType
   colorScheme: String
   videoUrl: String
   ownerId: String
   applicationType: AppType
   contacts: AppContactsInput
-  access: [AppAccessInput]
+  permissions: [AppPermissionsInput]
   feedback: AppFeedbackConfigInput
   search: AppMicroserviceConfigInput
   notifications: AppMicroserviceConfigInput
-}
-enum AppEntityType {
-  SPA
-  MICROSERVICE
 }
 enum AppType {
   BUILTIN
@@ -98,17 +90,19 @@ input AppContactsInput {
   qe: [String]
   stakeholders: [String]
 }
-type AppAccess {
-  roverGroup: String
-  role: AppAccessRole
+type AppPermissions {
+  refId: String
+  refType: AppPermissionsRefType
+  role: String
 }
-input AppAccessInput {
-  roverGroup: String
-  role: AppAccessRole
+input AppPermissionsInput {
+  refId: String!
+  refType: AppPermissionsRefType!
+  role: String!
 }
-enum AppAccessRole {
-  EDIT
-  VIEW
+enum AppPermissionsRefType {
+  User
+  Group
 }
 type AppFeedbackConfig {
   isEnabled: Boolean


### PR DESCRIPTION
## Adds

- Additional fields to the app model for future use cases for database and lighthouse configs.

## Fixes

- The appId for apps without any path or where the path is `/` was being generated as an empty string. Now the app name will be used as a fallback

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
