### PR TITLE
fix(ssi): Replaced the deprecated getHomeType query with the new apps query

### DIFF
--- a/packages/ssi-service/.env.example
+++ b/packages/ssi-service/.env.example
@@ -9,7 +9,8 @@ NODE_ENV=docker
 
 ## ENV variables for nav
 ASSETS_HOST=/.ssi/nav
-APPS_BASE_API=
+OP_API_GATEWAY_URL=
+OP_SUBSCRIPTIONS_URL=
 # OP_API_KEY=
 
 ## SSO Config

--- a/packages/ssi-service/src/feedback-panel/api.js
+++ b/packages/ssi-service/src/feedback-panel/api.js
@@ -27,7 +27,7 @@ sendFeedback = (feedbackInput) => {
             "input": feedbackInput
         }
     });
-    return fetch(process.env.APPS_BASE_API, {
+    return fetch( process.env.OP_API_GATEWAY_URL, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/packages/ssi-service/src/nav/api.js
+++ b/packages/ssi-service/src/nav/api.js
@@ -9,11 +9,11 @@ import { split } from 'apollo-link';
  */
 export class APIService {
   constructor () {
-    this._apiBasePath = process.env.APPS_BASE_API;
-    this._apiBaseURL = new URL( this._apiBasePath );
+    this._apiBasePath = process.env.OP_API_GATEWAY_URL;
+    this._subscriptionsPath = process.env.OP_SUBSCRIPTIONS_URL;
 
     this._wsLink = new WebSocketLink( {
-      uri: `wss://${ this._apiBaseURL.host }/subscriptions`,
+      uri: this._subscriptionsPath,
       options: {
         reconnect: true,
         connectionParams: () => ({ ...this._headers })
@@ -85,11 +85,11 @@ export class APIService {
   navDrawerData (targets) {
     const query = `
       query NavMenu ($targets: [String]!) {
-        appsList: getHomeTypeBy( input: {entityType: "spa"} ) {
+        appsList: apps {
           name
-          link
+          path
           icon
-          active
+          isActive
           applicationType
         }
         notificationsList: listArchivedNotifications(targets: $targets , limit: 25) {


### PR DESCRIPTION
# Explain the feature/fix

- `getHomeType` query has been deprecated in favour of new apps service
- also added a separate environment variable for subscriptions url

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
