### PR TITLE
fix(ssi-nav): Incorrect variable name in app drawer in SSI

### DIFF
--- a/packages/ssi-service/src/nav/nav.js
+++ b/packages/ssi-service/src/nav/nav.js
@@ -230,7 +230,7 @@ window.customElements.define( 'op-nav', class extends LitElement {
     <div class="op-menu-drawer__title"><span>Built-in Services</span></div>
     <ul class="op-menu-drawer__app-list">
       ${builtIn.map( app => ( html`
-        <li class="op-menu-drawer__app-list-item ${ app.active ? '' : 'inactive' }">
+        <li class="op-menu-drawer__app-list-item ${ app.isActive ? '' : 'inactive' }">
           <a .href="${ app.link }">
             <div>
               <img .src="${ app.icon || ASSETS_URL + '/rh-hat-logo.svg' }"/>
@@ -245,7 +245,7 @@ window.customElements.define( 'op-nav', class extends LitElement {
     <div class="op-menu-drawer__title"><span>Hosted Applications</span></div>
     <ul class="op-menu-drawer__app-list">
       ${hosted.map( app => ( html`
-      <li class="op-menu-drawer__app-list-item ${ app.active ? '' : 'inactive' }">
+      <li class="op-menu-drawer__app-list-item ${ app.isActive ? '' : 'inactive' }">
         <a .href="${ app.link }">
           <div>
             <img .src="${ app.icon || ASSETS_URL + '/rh-hat-logo.svg' }" />


### PR DESCRIPTION
# Fixes

Minor variable name change

# Explain the feature/fix

The field for app.active was changed to `isActive` in the new app service.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?