### PR TITLE
Feat(#1141): Fetching members details from cache as group API does not provide all the fields

### DIFF
--- a/packages/user-group-service/src/groups/resolver.ts
+++ b/packages/user-group-service/src/groups/resolver.ts
@@ -28,7 +28,8 @@ export const GroupResolver = {
       return UserGroupAPIHelper.roverFetch( `/groups/${ root.cn }` )
         .then( ( res ) => {
           const uids = res.result?.memberUids.map( ( member: string ) => {
-            return member.substring( 4, member.indexOf( ',ou' ) );
+            const uidPart = member.split( ',' ).find( (part) => part.startsWith("uid=") );
+            return uidPart && uidPart.substring(4);
           } );
           return Users.find( { "uid": { "$in": uids } } );
         } )

--- a/packages/user-group-service/src/groups/resolver.ts
+++ b/packages/user-group-service/src/groups/resolver.ts
@@ -1,4 +1,5 @@
 import { Groups } from './schema';
+import { Users } from '../users/schema';
 import { UserGroupAPIHelper } from '../helpers';
 
 export const GroupResolver = {
@@ -25,12 +26,13 @@ export const GroupResolver = {
   Group: {
     members ( root: any, GraphQLArgs: any, ctx: any ) {
       return UserGroupAPIHelper.roverFetch( `/groups/${ root.cn }` )
-            .then( ( res ) => {
-              return res.result?.memberUids.map( ( member: string ) => {
-                return member.substring( 4, member.indexOf( ',ou' ) );
-              } );
-            } )
-            .catch((err) => { throw("There is some problem fetching members of the group ") });
+        .then( ( res ) => {
+          const uids = res.result?.memberUids.map( ( member: string ) => {
+            return member.substring( 4, member.indexOf( ',ou' ) );
+          } );
+          return Users.find( { "uid": { "$in": uids } } );
+        } )
+        .catch((err) => { throw("There is some problem fetching members of the group.") });
       }
   },
   Mutation: {

--- a/packages/user-group-service/src/groups/typedef.graphql
+++ b/packages/user-group-service/src/groups/typedef.graphql
@@ -30,27 +30,6 @@ type Mutation {
 
 scalar DateTime
 
-type UserType {
-  _id: String
-  uid: String
-  name: String @deprecated(reason: "Field is deprecated!")
-  cn: String
-  isActive: Boolean
-  rhatJobTitle: String
-  title: String @deprecated(reason: "Field is deprecated!")
-  rhatCostCenter: String
-  rhatCostCenterDesc: String
-  employeeType: String
-  rhatOfficeLocation: String
-  mail: String
-  rhatUUID: String
-  serviceAccount: Boolean
-  manager: UserType
-  roverGroups: [GroupType]
-  createdOn: DateTime
-  updatedOn: DateTime
-}
-
 type Group {
   _id: ID
   cn: String

--- a/packages/user-group-service/src/groups/typedef.graphql
+++ b/packages/user-group-service/src/groups/typedef.graphql
@@ -10,7 +10,7 @@ type Query {
   """
   Returns a group
   """
-  group( cn: String ): Group
+  group( cn: String! ): Group
 }
 
 type Mutation {
@@ -30,13 +30,34 @@ type Mutation {
 
 scalar DateTime
 
+type UserType {
+  _id: String
+  uid: String
+  name: String @deprecated(reason: "Field is deprecated!")
+  cn: String
+  isActive: Boolean
+  rhatJobTitle: String
+  title: String @deprecated(reason: "Field is deprecated!")
+  rhatCostCenter: String
+  rhatCostCenterDesc: String
+  employeeType: String
+  rhatOfficeLocation: String
+  mail: String
+  rhatUUID: String
+  serviceAccount: Boolean
+  manager: UserType
+  roverGroups: [GroupType]
+  createdOn: DateTime
+  updatedOn: DateTime
+}
+
 type Group {
   _id: ID
   cn: String
   name: String
   createdOn: DateTime
   updatedOn: DateTime
-  members: [String]
+  members: [UserType]
 }
 
 input AddGroupInput {


### PR DESCRIPTION
# Closes/Fixes/Resolves
Supplements ONEPLAT-1141

# Explain the feature/fix
Fetching members details from cache as group API does not provide all the fields

## Does this PR introduce a breaking change
Yes

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshots below this line -->

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
