### PR TITLE
feat(dev-console): Adds AppSettings page to modify apps

### DIFF
--- a/packages/developer-console-spa/src/App.tsx
+++ b/packages/developer-console-spa/src/App.tsx
@@ -11,6 +11,7 @@ import UnderDevelopment from './components/UnderDevelopment';
 import ConfigureFeedback from './components/ConfigureFeedback';
 import ConfigureSSI from './components/ConfigureSSI';
 import ConfigureDatabase from './components/ConfigureDatabase';
+import AppSettings from './components/AppSettings';
 
 function App() {
   return (
@@ -29,6 +30,7 @@ function App() {
               <Route path="/:appId/search" component={ UnderDevelopment } exact />
               <Route path="/:appId/notifications" component={ UnderDevelopment } exact />
               <Route path="/:appId/user-groups" component={ UnderDevelopment } exact />
+              <Route path="/:appId/settings" component={ AppSettings } exact />
               <Route path="*" component={ NotFound } />
             </Switch>
           </AppConsoleShell>

--- a/packages/developer-console-spa/src/components/AddAppForm.tsx
+++ b/packages/developer-console-spa/src/components/AddAppForm.tsx
@@ -35,14 +35,17 @@ export default function AppAppForm () {
 
   function handleFormSubmit (event: any) {
     event.preventDefault();
-    console.log( app );
     /* TODO: Form validation before submitting */
     gqlClient( { query: newApp, variables: { app } } )
       .then( res => {
         if ( res?.data?.app ) {
+          window.OpNotification.success( { subject: 'App Created Succssfully!' } );
           history.push( res.data.app.appId );
         }
-      } );
+      } ).catch( err => {
+        window.OpNotification.danger( { subject: 'An error occured when deleting the App.', body: 'Please try again later.' } );
+        console.error( err );
+      });
   }
 
   return <>

--- a/packages/developer-console-spa/src/components/AppIndex.tsx
+++ b/packages/developer-console-spa/src/components/AppIndex.tsx
@@ -8,9 +8,9 @@ import './AppIndex.css'
 function AppIndex () {
   const { apps, loading } = useMyAppsAPI();
 
-  const cardDropdownItems = [
-    <DropdownItem key='edit'>Edit App</DropdownItem>,
-    <DropdownItem key='delete' className="pf-u-danger-color-100">Delete App</DropdownItem>,
+  const cardDropdownItems = (appId: string) => [
+    <DropdownItem key='edit' href={ process.env.PUBLIC_URL + '/' + appId + '/settings' }>Edit App</DropdownItem>,
+    <DropdownItem key='delete' className="pf-u-danger-color-100" href={ process.env.PUBLIC_URL + '/' + appId + '/settings?action=delete' }>Delete App</DropdownItem>,
   ];
 
   function NewAppButton () {
@@ -50,7 +50,7 @@ function AppIndex () {
                   <GridItem key={app.id}>
                     <AppCard
                       app={app}
-                      dropdownItems={ cardDropdownItems } />
+                      dropdownItems={ cardDropdownItems(app.appId) } />
                   </GridItem>
                 ) }
               </Grid>

--- a/packages/developer-console-spa/src/components/AppOverview.tsx
+++ b/packages/developer-console-spa/src/components/AppOverview.tsx
@@ -60,8 +60,8 @@ function AppOverview () {
                   isSelected={false}
                   actions={
                     <MenuItemAction
-                      icon={<Switch
-                      onClickCapture={ ( event ) => event.stopPropagation() }
+                    icon={ <Switch
+                      isDisabled={true}
                       id={ 'switch-' + service.id }
                       aria-label={ service.name }
                       isChecked={ service.isActive }

--- a/packages/developer-console-spa/src/components/AppSettings.tsx
+++ b/packages/developer-console-spa/src/components/AppSettings.tsx
@@ -1,0 +1,200 @@
+import { useContext, useEffect, useState } from 'react';
+import { AppContext } from '../context/AppContext';
+import Loader from './Loader';
+import {
+  Card, CardTitle, CardBody, CardFooter,
+  Form, FormGroup,
+  Grid, GridItem,
+  Title, Text, TextInput, TextArea,
+  Stack, StackItem,
+  Menu, MenuContent, MenuList, MenuItem, MenuItemAction,
+  Switch, Button, Modal
+} from '@patternfly/react-core';
+import { deleteAppService, updateAppService } from '../services/app';
+import { useHistory, useLocation } from 'react-router-dom';
+
+function AppSettings () {
+  const history = useHistory();
+  const location = useLocation();
+  const { app, loading, forceRefreshApp } = useContext( AppContext );
+  const [ editableApp, setEditableApp ] = useState( app );
+  const [ isDeleteModalOpen, setDeleteModalOpen ] = useState( false );
+  const [ deleteAppConfirmation, setDeleteAppConformation ] = useState( '' );
+
+  useEffect( () => {
+    setEditableApp( app );
+  }, [ app ] );
+
+  useEffect( () => {
+    const searchParams = new URLSearchParams( location.search );
+    if ( searchParams.get('action') === 'delete' ) {
+      setDeleteModalOpen( true );
+    } else {
+      setDeleteModalOpen( false );
+    }
+  }, [location] );
+
+  const handleResetApp = (event: any) => {
+    event.preventDefault();
+    setEditableApp( app );
+  }
+  const handleSaveApp = (event: any) => {
+    event.preventDefault();
+
+    /* TODO: Add form validation */
+
+    updateAppService( editableApp )
+      .then( updatedApp => {
+        forceRefreshApp( updatedApp );
+        window.OpNotification.success( { subject: 'App Updated Succssfully!' } );
+      } )
+      .catch( err => {
+        window.OpNotification.danger( { subject: 'An error occured when updating the App.', body: 'Please try again later.' } );
+        console.error( err );
+      } );
+  }
+
+
+  const handleAppDeactivateToggle = () => {
+    /* TODO: gqlQuery for toggling `isActive` */
+  }
+
+  const handleDeleteApp = (event: any) => {
+    event.preventDefault();
+    deleteAppService( app.id )
+      .then( () => {
+        window.OpNotification.success( { subject: 'App Deleted Succssfully!' } );
+        history.push( '/' );
+      } )
+      .catch( err => {
+        window.OpNotification.danger( { subject: 'An error occured when deleting the App.', body: 'Please try again later.' } );
+        console.error( err );
+      } );
+  }
+
+  const handleModalClose = () => {
+    /* Remove the new=true from the url search params */
+    const searchParams = new URLSearchParams( location.search );
+    searchParams.delete( 'action' );
+    history.replace( { search: searchParams.toString() } );
+    setDeleteAppConformation( '' );
+  }
+
+  if ( loading ) {
+    return <Loader />;
+  }
+  return (
+    <>
+      <Card isPlain>
+        <CardBody>
+          <Title headingLevel="h1">App Settings</Title>
+        </CardBody>
+      </Card>
+      <Stack hasGutter>
+        <StackItem>
+          <Form onSubmit={ handleSaveApp } onReset={ handleResetApp }>
+            <Card isRounded>
+              <CardBody>
+                <Grid hasGutter>
+                  <GridItem>
+                    <FormGroup fieldId="name" label="App Name" isRequired>
+                      <TextInput
+                        id="name"
+                        placeholder="Enter a name for your project"
+                        value={ editableApp.name }
+                        onChange={ name => setEditableApp( { ...editableApp, name } ) }
+                        isRequired></TextInput>
+                    </FormGroup>
+                  </GridItem>
+                  <GridItem>
+                    <FormGroup fieldId="path" label="App Path" helperText="The path where your app will be hosted." isRequired>
+                      <TextInput
+                        id="path"
+                        placeholder="/app-path"
+                        value={ editableApp.path }
+                        onChange={ path => setEditableApp( { ...editableApp, path } ) }
+                        isRequired></TextInput>
+                    </FormGroup>
+                  </GridItem>
+                  <GridItem>
+                    <FormGroup fieldId="description" label="Description">
+                      <TextArea
+                        id="description"
+                        placeholder="Enter a description for your project"
+                        value={ editableApp.description }
+                        onChange={ description => setEditableApp( { ...editableApp, description } ) }></TextArea>
+                    </FormGroup>
+                  </GridItem>
+                </Grid>
+              </CardBody>
+              <CardFooter>
+                <Button variant="primary" type="submit">Update</Button>
+                <Button variant="link" type="reset">Discard</Button>
+              </CardFooter>
+            </Card>
+          </Form>
+        </StackItem>
+        <StackItem>
+          <Card isRounded isFlat style={ { border: '1px solid var(--pf-global--danger-color--100)', overflow: 'hidden'}}>
+            <CardTitle className="pf-u-danger-color-100">Danger Zone</CardTitle>
+            <Menu style={ { boxShadow: 'none' } }>
+              <MenuContent>
+                <MenuList>
+                  <MenuItem
+                    isDisabled
+                    description="Deactivates the app from One Platform Menu and the Homepage"
+                    itemId={ 0 }
+                    actions={
+                      <MenuItemAction
+                        actionId="deactivate"
+                        icon={ <Switch
+                          isDisabled
+                          id="deactivate-app"
+                          aria-label="Deactivate app"
+                          isChecked={ false }
+                          value={editableApp.isActive}
+                          onClick={ handleAppDeactivateToggle } /> }
+                        aria-label="Deactivate the app" />
+                    }>
+                    Deactivate App
+                    </MenuItem>
+                  <MenuItem
+                    description="Deletes the app from One Platform. Cannot be reverted."
+                    itemId={ 1 }
+                    onClick={ () => history.push({ search: 'action=delete' }) }
+                    actions={
+                      <MenuItemAction
+                        actionId="delete"
+                        icon={ <ion-icon class="pf-u-danger-color-100" name="trash" /> }
+                        aria-label="Delete the app" />
+                    }>
+                    <span className="pf-u-danger-color-100">Delete this App</span>
+                  </MenuItem>
+                </MenuList>
+              </MenuContent>
+            </Menu>
+          </Card>
+        </StackItem>
+      </Stack>
+      <Modal
+        variant="small"
+        isOpen={ isDeleteModalOpen }
+        aria-label="Delete App Modal"
+        title="Are you sure?"
+        titleIconVariant="danger"
+        showClose={ true }
+        onClose={ handleModalClose }>
+        <Text>This action is irreversible and will permanently delete the <strong><em>{ app.name }</em></strong> app from One Platform.</Text>
+        <br/>
+        <Form onSubmit={ handleDeleteApp }>
+          <FormGroup fieldId="delete-app" label={ `Please type "${ app.name }" to confirm` } isRequired>
+            <TextInput id="delete-app" autoFocus onChange={ val => setDeleteAppConformation(val)} isRequired></TextInput>
+          </FormGroup>
+          <Button variant="danger" type="submit" isDisabled={ app.name !== deleteAppConfirmation }>I understand the consequences, delete this app</Button>
+        </Form>
+      </Modal>
+    </>
+  );
+}
+
+export default AppSettings;

--- a/packages/developer-console-spa/src/components/Sidebar.tsx
+++ b/packages/developer-console-spa/src/components/Sidebar.tsx
@@ -7,7 +7,7 @@ import './Sidebar.css';
 
 function Sidebar () {
   const { apps } = useMyAppsAPI();
-  const { app, loading } = useContext( AppContext );
+  const { app, loading, setApp } = useContext( AppContext );
   const { appId } = useParams<any>();
 
   const location = useLocation();
@@ -21,11 +21,12 @@ function Sidebar () {
       <OptionsMenuItem
         key={ tapp.id }
         id={ tapp.id }
-        isSelected={ tapp.appId === appId }>
+        isSelected={ tapp.appId === appId }
+        onSelect={ () => {setApp( tapp.appId ); setAppsListOpen( false )} }>
         { tapp.name }
       </OptionsMenuItem>
     ) ) );
-  }, [ apps, appId ] );
+  }, [ apps, appId, setApp, setAppsListOpen ] );
 
   const appsMenuToggle = <OptionsMenuToggle onToggle={ () => {setAppsListOpen( !appsListOpen )} } toggleTemplate={ loading ? 'Loading...' : app?.name }></OptionsMenuToggle>;
 
@@ -45,6 +46,7 @@ function Sidebar () {
     <>
       <Nav theme="light" className="app-details--sidebar pf-u-box-shadow-md-right">
 
+        {/* TODO: use context selector instead of options menu (https://www.patternfly.org/v4/components/context-selector) */}
         <OptionsMenu
           className="app-menu--list"
           id="app-list-options-menu"
@@ -71,8 +73,11 @@ function Sidebar () {
           ))}
         </NavList>
         <NavList className="app-details--sidebar--settings pf-u-mt-auto">
-          <NavItem>App Settings
-           <ion-icon class="pf-u-ml-auto pf-u-my-auto" name="settings-outline"></ion-icon>
+          <NavItem>
+            <Link to={ 'settings' }>
+              App Settings
+              <ion-icon class="pf-u-ml-auto pf-u-my-auto" name="settings-outline"></ion-icon>
+            </Link>
           </NavItem>
         </NavList>
         </Nav>

--- a/packages/developer-console-spa/src/context/AppContext.tsx
+++ b/packages/developer-console-spa/src/context/AppContext.tsx
@@ -1,16 +1,28 @@
 import { createContext } from 'react';
-import { useParams } from 'react-router';
+import { useHistory, useParams } from 'react-router';
+import { useLocation } from 'react-router-dom';
 import useAppAPI from '../hooks/useAppAPI';
 
 export const AppContext = createContext<any>( {} );
 
 export default function AppContextProvider ( props: any ) {
   const { appId } = useParams<any>();
+  const router = useHistory();
+  const location = useLocation();
 
-  const { app, loading } = useAppAPI(appId);
+  const { app, loading, setApp: setOriginalApp } = useAppAPI(appId);
+
+  const setApp = (newAppId: string) => {
+    const newPath = location.pathname.replace( appId, newAppId ) + location.search + location.hash;
+    router.push( newPath );
+  }
+
+  const forceRefreshApp = ( newApp: any ) => {
+    setOriginalApp( { ...app, ...newApp} );
+  }
 
   return (
-    <AppContext.Provider value={{ app, loading }}>
+    <AppContext.Provider value={ { app, loading, setApp, forceRefreshApp }}>
       {props.children}
     </AppContext.Provider>
   )

--- a/packages/developer-console-spa/src/hooks/useAppAPI.ts
+++ b/packages/developer-console-spa/src/hooks/useAppAPI.ts
@@ -10,6 +10,8 @@ export default function useAppAPI ( appId: string ) {
     const abortController = new AbortController();
     const signal = abortController.signal;
 
+    setLoading( true );
+
     gqlClient( { query: appByAppId, variables: { appId } }, signal )
       .then( res => {
         if ( !res?.data?.app ) {
@@ -23,5 +25,5 @@ export default function useAppAPI ( appId: string ) {
     return () => abortController.abort();
   }, [ appId ] );
 
-  return { app, loading };
+  return { app, loading, setApp };
 }

--- a/packages/developer-console-spa/src/react-app-env.d.ts
+++ b/packages/developer-console-spa/src/react-app-env.d.ts
@@ -8,4 +8,5 @@ declare namespace NodeJS {
 
 declare interface Window {
   OpAuthHelper?: any;
+  OpNotification?: any;
 }

--- a/packages/developer-console-spa/src/services/app.ts
+++ b/packages/developer-console-spa/src/services/app.ts
@@ -1,0 +1,30 @@
+import { pick } from 'lodash';
+import { deleteApp, updateApp } from '../utils/gql-queries';
+import gqlClient from '../utils/gqlClient';
+
+export const updateAppService = async ( updatedApp: any ) => {
+  try {
+    const app = pick( updatedApp, [ 'name', 'path', 'description' ] );
+    const res = await gqlClient( { query: updateApp, variables: { id: updatedApp.id, app } } );
+    if ( res.errors && !res?.data?.updateApp ) {
+      const errMessage = res.errors.map( ( err: any ) => err.message ).join( ', ' );
+      throw new Error( errMessage );
+    }
+    return res.data.updateApp;
+  } catch ( err ) {
+    throw err;
+  }
+}
+
+export const deleteAppService = async ( id: string ) => {
+  try {
+    const res = await gqlClient( { query: deleteApp, variables: { id } } );
+    if ( res.errors && !res?.data?.deletApp ) {
+      const errMessage = res.errors.map( ( err: any ) => err.message ).join( ', ' );
+      throw new Error( errMessage );
+    }
+    return res.data.deleteApp;
+  } catch ( err ) {
+    throw err;
+  }
+}

--- a/packages/developer-console-spa/src/utils/gql-queries/delete-app.ts
+++ b/packages/developer-console-spa/src/utils/gql-queries/delete-app.ts
@@ -1,0 +1,9 @@
+export const deleteApp = /* GraphQL */`
+mutation DeleteApp($id: ID!) {
+  deleteApp(id: $id) {
+    id
+    name
+    appId
+  }
+}
+`;

--- a/packages/developer-console-spa/src/utils/gql-queries/index.ts
+++ b/packages/developer-console-spa/src/utils/gql-queries/index.ts
@@ -1,2 +1,5 @@
 export * from './my-apps';
+export * from './app-by-appid';
 export * from './new-app';
+export * from './update-app';
+export * from './delete-app';

--- a/packages/developer-console-spa/src/utils/gql-queries/update-app.ts
+++ b/packages/developer-console-spa/src/utils/gql-queries/update-app.ts
@@ -1,0 +1,11 @@
+export const updateApp = /* GraphQL */`
+mutation UpdateApp($id: ID!, $app: UpdateAppInput!) {
+  updateApp(id: $id, app: $app) {
+    id
+    name
+    appId
+    path
+    description
+  }
+}
+`;


### PR DESCRIPTION
# Closes

ONEPLAT-1057

# Explain the feature/fix

- Implemented an App Settings page where users can modify the app information
- With editable form for modifying the basic details of the app, along with the ability to archive, disable and delete the app entirely.

## Does this PR introduce a breaking change

No.

## Screenshots

<details>
<summary>View Screenshots</summary>

- App Settings Page
<img width="1422" alt="Screenshot 2021-07-13 at 9 29 23 PM" src="https://user-images.githubusercontent.com/19623278/125485562-ece676ac-957e-4c95-94be-b9b9e3a61daf.png">

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did tests pass?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
