### PR TITLE
(docs/apps): Adds documentation for App Service and some permalink changes for other docs

### DIFF
--- a/e2e/helper/apps.list.js
+++ b/e2e/helper/apps.list.js
@@ -27,11 +27,11 @@ export const microservicesDesc = [
 ];
 
 export const microservicesReadmore = [
-    "/get-started/docs/microservices/authorization/authorization-service/",
-    "/get-started/docs/microservices/feedback/feedback-service/",
-    "/get-started/docs/microservices/notifications/notifications-service/",
-    "/get-started/docs/microservices/user-groups/user-groups-service/",
-    "/get-started/docs/microservices/search/search-service/"
+    "/get-started/docs/microservices/authorization-service/",
+    "/get-started/docs/microservices/feedback-service/",
+    "/get-started/docs/microservices/notifications-service/",
+    "/get-started/docs/microservices/user-groups-service/",
+    "/get-started/docs/microservices/search-service/"
 ];
 
 export const inBuiltApps = [

--- a/packages/documentation-spa/blog/2020-08-18-announcing-one-platform-beta.md
+++ b/packages/documentation-spa/blog/2020-08-18-announcing-one-platform-beta.md
@@ -12,7 +12,7 @@ We are happy to announce the Beta release for [One Platform](https://beta.one.re
 ## Highlights of this release
 
 - Enhancements to the [Home page](https://beta.one.redhat.com/) for seamless user experience.
-- Enhancements to the [User & Group microservice](https://beta.one.redhat.com/get-started/docs/microservices/user-groups/user-groups-service/) for implementing a consolidated team framework.
+- Enhancements to the [User & Group microservice](https://beta.one.redhat.com/get-started/docs/microservices/user-groups-service/) for implementing a consolidated team framework.
 - One Portal Migration: Complete [MoD Handovers](https://beta.one.redhat.com/mod-handovers/) SPA Beta UI release.
 - Analyst Papers SPA: [Beta UI](https://beta.one.redhat.com/analyst-papers) release that includes Listing, Search, Quote, Quick Preview and Google Drive integration.
 - Integrations: Rover Groups and Google Drive.

--- a/packages/documentation-spa/docs/apps/assets.md
+++ b/packages/documentation-spa/docs/apps/assets.md
@@ -2,6 +2,7 @@
 id: assets
 title: One Platform Assets
 sidebar_label: Assets
+slug: /apps/assets
 ---
 * * *
 

--- a/packages/documentation-spa/docs/apps/hosted/mod-handovers/mod-handover-spa.md
+++ b/packages/documentation-spa/docs/apps/hosted/mod-handovers/mod-handover-spa.md
@@ -2,6 +2,7 @@
 id: mod-handover-spa
 title: MoD Handovers
 sidebar_label: MoD Handovers
+slug: /apps/hosted/mod-handovers
 ---
 * * *
 # MoD Handover SPA

--- a/packages/documentation-spa/docs/apps/hosted/research-repository/research-repository-spa.md
+++ b/packages/documentation-spa/docs/apps/hosted/research-repository/research-repository-spa.md
@@ -2,6 +2,7 @@
 id: research-repository-spa
 title: Research Repository
 sidebar_label: Research Repository
+slug: /apps/hosted/research-repository
 ---
 * * *
 

--- a/packages/documentation-spa/docs/apps/internal/feedback/feedback-spa.md
+++ b/packages/documentation-spa/docs/apps/internal/feedback/feedback-spa.md
@@ -2,6 +2,7 @@
 id: feedback-spa
 title: Feedback
 sidebar_label: Feedback
+slug: /apps/internal/feedback
 ---
 ## Developers
 

--- a/packages/documentation-spa/docs/apps/internal/home/home-spa.md
+++ b/packages/documentation-spa/docs/apps/internal/home/home-spa.md
@@ -2,6 +2,7 @@
 id: home-spa
 title: Home
 sidebar_label: Home
+slug: /apps/internal/home
 ---
 * * *
 

--- a/packages/documentation-spa/docs/apps/internal/notifications/notifications-spa.md
+++ b/packages/documentation-spa/docs/apps/internal/notifications/notifications-spa.md
@@ -2,6 +2,7 @@
 id: notifications-spa
 title: Notifications
 sidebar_label: Notifications
+slug: /apps/internal/notifications
 ---
 * * *
 

--- a/packages/documentation-spa/docs/apps/internal/ssi-service/ssi-service.md
+++ b/packages/documentation-spa/docs/apps/internal/ssi-service/ssi-service.md
@@ -2,6 +2,7 @@
 id: ssi-service
 title: SSI Service
 sidebar_label: SSI Service
+slug: /apps/internal/ssi
 ---
 * * *
 

--- a/packages/documentation-spa/docs/apps/internal/user-groups/user-groups-spa.md
+++ b/packages/documentation-spa/docs/apps/internal/user-groups/user-groups-spa.md
@@ -2,6 +2,7 @@
 id: user-groups-spa
 title: User Groups
 sidebar_label: User Groups
+slug: /apps/internal/user-groups
 ---
 * * *
 

--- a/packages/documentation-spa/docs/cli/op-cli.md
+++ b/packages/documentation-spa/docs/cli/op-cli.md
@@ -2,6 +2,7 @@
 id: op-cli
 title: One Platform CLI
 sidebar_label: One Platform CLI
+slug: /cli
 ---
 * * *
 

--- a/packages/documentation-spa/docs/components/component-library.md
+++ b/packages/documentation-spa/docs/components/component-library.md
@@ -2,6 +2,7 @@
 id: component-library
 title: Component Library
 sidebar_label: Component Library
+slug: /component-library
 ---
 * * *
 

--- a/packages/documentation-spa/docs/documentation/styleguide.md
+++ b/packages/documentation-spa/docs/documentation/styleguide.md
@@ -2,6 +2,7 @@
 id: styleguide
 title: Style Guide
 sidebar_label: Style Guide
+slug: /component-library/style-guide
 ---
 
 You can write content using [GitHub-flavored Markdown syntax](https://github.github.com/gfm/).

--- a/packages/documentation-spa/docs/faqs.md
+++ b/packages/documentation-spa/docs/faqs.md
@@ -2,6 +2,7 @@
 id: faqs
 title: One Platform FAQs
 sidebar_label: One Platform FAQs
+slug: /faqs
 ---
 ***
 

--- a/packages/documentation-spa/docs/getting-started/get-started.md
+++ b/packages/documentation-spa/docs/getting-started/get-started.md
@@ -14,7 +14,7 @@ slug: /
 
 ### Deploying to One Platform
   #### Setting up the SPAship CLI.
-- SPAship is an open source platform for deploying, integrating, and managing single-page apps (SPAs). 
+- SPAship is an open source platform for deploying, integrating, and managing single-page apps (SPAs).
 - SPAship have a CLI client which enables to push the SPA to the specified environments.
 
 ```sh
@@ -36,7 +36,7 @@ npm install -g @spaship/cli
   - Create .spashiprc.yaml in the home folder and add the api keys and SPAship urls.  Based on the SPAship Instances QA and Stage environment urls also need to be included.
 
 ```sh
-$ cat ~/.spashiprc.yml 
+$ cat ~/.spashiprc.yml
 envs:
   qa:
     url: https://op-spaship-qa-api.cloud.paas.psi.redhat.com
@@ -49,7 +49,7 @@ envs:
 #### Using the Spaship deploy command.
   - SPAship allows the user to deploy the packaged version of the SPA build. Based on the Technology stack you use to build the SPA generate the build accordingly.
   - Execute spaship init command to include the spaceship configuration on build
-  - Switch the working directory into the *dist* folder. Pack the dist folder of SPA using zip utility. 
+  - Switch the working directory into the *dist* folder. Pack the dist folder of SPA using zip utility.
 
 `zip spa.zip .`
 
@@ -84,7 +84,7 @@ Total: 14 seconds
     - Following SSI Code snippet is a universal web property for using the SSI with the SPA. This needs to be injected with the root of your spa inside the <body></body> tag.
 
 ```html
-<!-- SSI Include Snippet --> 
+<!-- SSI Include Snippet -->
 <!--#include virtual="/.ssi/nav/default.html" -->
 
 ```

--- a/packages/documentation-spa/docs/microservices/apps-service/app-service.md
+++ b/packages/documentation-spa/docs/microservices/apps-service/app-service.md
@@ -1,0 +1,101 @@
+---
+id: apps-service
+title: Apps Service
+sidebar_label: Apps Service
+slug: /microservices/apps-service
+---
+***
+
+Apps Service is the indexing service which allows you to create and manage individual apps/projects on One Platform. It provides CRUD operations for the app metadata.
+
+## Getting Started
+
+Any developer can use the Apps Service to view the metadata for their apps, and to configure the One Platform Microservice integrations.
+
+To get started with the Apps Service, follow the steps below:
+
+1. Register your app on the [One Platform Developer Console](https://one.redhat.com/console)
+2. Setup an API Key for your app/project
+3. Now you can use the API Key for authenticated access to the One Platform API Gateway to access the GraphQL APIs
+
+## GraphQL API Reference
+
+You can test drive the available GraphQL APIs on the QA testing playground here:
+https://api.qa.one.redhat.com/graphql
+
+Some of the queries and mutations available for use are:
+
+### Apps
+
+<details><summary>Queries</summary>
+
+| Query | Description |
+|---|---|
+| `myApps` | Returns a list of all Apps you have registered. The user id is deduced from the Authorization header (i.e. JWT Token or the API Key) |
+| `app(appId: String!)` | Returns the metadata of a single app by it's unique `appId` |
+| `findApps(selectors: FindAppsInput!)` | Used to find an app by any of the available fields |
+
+</details>
+
+<details><summary>Mutations</summary>
+
+| Mutation | Description |
+|---|---|
+| `createApp(app: CreateAppInput!)` | Creates/Registers a new app/project |
+| `updateApp(id: ID!, app: UpdateAppInput!)` | Update/modify the metadata of your existing app/project |
+| `deleteApp(id: ID!)` | Delete an existing app/project |
+
+</details>
+
+### Microservices
+
+<details><summary>Queries</summary>
+
+| Query | Description |
+|---|---|
+| `myServices` | Returns a list of all services you have registered. The user id is deduced from the Authorization header (i.e. JWT Token or the API Key) |
+| `service(serviceId: String!)` | Returns the metadata of a single service by it's unique `serviceId` |
+| `findServices(selectors: FindServiceInput!)` | Used to find an service by any of the available fields |
+
+</details>
+
+<details><summary>Mutations</summary>
+
+| Mutation | Description |
+|---|---|
+| `createService(service: CreateServiceInput!)` | Creates a new Service |
+| `updateService(id: ID!, service: UpdateServiceInput!)` | Update/modify the metadata of an existing service |
+| `deleteService(id: ID!)` | Delete an existing service |
+
+</details>
+
+## Apps using this microservice:
+
+- Developer Console SPA
+- Homepage and Global Navigation
+
+## Developers
+
+- Mayur Deshmukh – mdeshmuk@redhat.com
+
+## FAQs
+
+<details><summary>Who is the App Service APIs for?</summary>
+The App Service APIs are for any developer who wants use the metadata of an app they have registered on the One Platform.
+</details>
+
+<details><summary>Can anyone create an App? How do I create a new App?</summary>
+Yes. Anyone can create an app as long as you have an internal Red Hat account (i.e. as long as you are a Red Hat employee).
+
+To create a new App, it is recommended to use the [Developer Console UI](https://one.redhat.com/console) as it provides a graphical interface for quickly and easily creating an app/project on One Platform.
+</details>
+
+<details><summary>I already have an app created, can I still register an existing app?</summary>
+Yes. If you want to integrate you app with any of the One Platform Microservices, registering you app in the Apps Service (via the Developer Console or the Apps Service APIs) is the easiest way to do so.
+</details>
+
+<details><summary>What is the difference between Apps and Services in the App Service?</summary>
+The Apps are any app or projects you have or that you are working on.
+
+The Services are reserved for the metadata of the One Platform's internal microservices.
+</details>

--- a/packages/documentation-spa/docs/microservices/authorization/authorization-service.md
+++ b/packages/documentation-spa/docs/microservices/authorization/authorization-service.md
@@ -2,6 +2,7 @@
 id: authorization-service
 title: Authorization Service
 sidebar_label: Authorization Service
+slug: /microservices/authorization
 ---
 * * *
 

--- a/packages/documentation-spa/docs/microservices/feedback/feedback-service.md
+++ b/packages/documentation-spa/docs/microservices/feedback/feedback-service.md
@@ -2,6 +2,7 @@
 id: feedback-service
 title: Feedback Service
 sidebar_label: Feedback Service
+slug: /microservices/feedback-service
 ---
 
 ## Developers

--- a/packages/documentation-spa/docs/microservices/home/home-service.md
+++ b/packages/documentation-spa/docs/microservices/home/home-service.md
@@ -2,12 +2,13 @@
 id: home-service
 title: Home Service
 sidebar_label: Home Service
+slug: /microservices/home-service
 ---
 ***
 
-## Developers
+> This service is being deprecated, and the related APIs will be removed soon. Please see apps-service for the updated APIs.
 
-### Component Contributors
+## Developers
 
 1. Deepesh Nair - [denair@redhat.com](mailto:denair@redhat.com)
 

--- a/packages/documentation-spa/docs/microservices/notifications/get-started.md
+++ b/packages/documentation-spa/docs/microservices/notifications/get-started.md
@@ -2,6 +2,7 @@
 id: notifications-get-started
 title: Getting Started with Notification Templates
 sidebar_label: Get Started with Templates
+slug: /microservices/notifications-service/get-started
 ---
 ***
 

--- a/packages/documentation-spa/docs/microservices/notifications/notifications-service.md
+++ b/packages/documentation-spa/docs/microservices/notifications/notifications-service.md
@@ -2,6 +2,7 @@
 id: notifications-service
 title: Notifications Service
 sidebar_label: Notifications Service
+slug: /microservices/notifications-service
 ---
 ***
 

--- a/packages/documentation-spa/docs/microservices/search/search-service.md
+++ b/packages/documentation-spa/docs/microservices/search/search-service.md
@@ -2,6 +2,7 @@
 id: search-service
 title: Search Service
 sidebar_label: Search Service
+slug: /microservices/search-service
 ---
 
 ## Developers

--- a/packages/documentation-spa/docs/microservices/user-groups/user-groups-service.md
+++ b/packages/documentation-spa/docs/microservices/user-groups/user-groups-service.md
@@ -2,6 +2,7 @@
 id: user-groups-service
 title: User/Group Service
 sidebar_label: User/Group Service
+slug: /microservices/user-groups-service
 ---
 ***
 

--- a/packages/documentation-spa/package-lock.json
+++ b/packages/documentation-spa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "documentation-spa",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/documentation-spa/package.json
+++ b/packages/documentation-spa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "documentation-spa",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/packages/documentation-spa/sidebars.js
+++ b/packages/documentation-spa/sidebars.js
@@ -1,40 +1,63 @@
 module.exports = {
-  someSidebar: {
-    Applications: [
-      'apps/assets',
-      {
-        Hosted: [
-          'apps/hosted/research-repository/research-repository-spa',
-          'apps/hosted/mod-handovers/mod-handover-spa'
-        ]
-      },
-      {
-        Internal: [
-          'apps/internal/feedback/feedback-spa',
-          'apps/internal/home/home-spa',
-          'apps/internal/notifications/notifications-spa',
-          'apps/internal/user-groups/user-groups-spa',
-          'apps/internal/ssi-service/ssi-service'
-        ]
-      },
-    ],
-    CLI: [ 'cli/op-cli' ],
-    Components: [ 'components/component-library' ],
-    GettingStarted: [ 'getting-started/getting-started' ],
-    Documentation: [ 'documentation/styleguide' ],
-    Microservices: [
-      'microservices/authorization/authorization-service',
-      'microservices/feedback/feedback-service',
-      'microservices/home/home-service',
-      {
-        Notifications: [
-          'microservices/notifications/notifications-service',
-          'microservices/notifications/notifications-get-started',
-        ]
-      },
-      'microservices/user-groups/user-groups-service',
-      'microservices/search/search-service',
-    ],
-    FAQs: [ 'faqs' ],
-  },
+  someSidebar: [
+    'getting-started/getting-started',
+    {
+      type: 'category',
+      label: 'Applications',
+      collapsed: false,
+      items: [
+        'apps/assets',
+        {
+          type: 'category',
+          label: 'Hosted',
+          items: [
+            'apps/hosted/research-repository/research-repository-spa',
+            'apps/hosted/mod-handovers/mod-handover-spa'
+          ]
+        },
+        {
+          type: 'category',
+          label: 'Internal',
+          items: [
+            'apps/internal/feedback/feedback-spa',
+            'apps/internal/home/home-spa',
+            'apps/internal/notifications/notifications-spa',
+            'apps/internal/user-groups/user-groups-spa',
+            'apps/internal/ssi-service/ssi-service'
+          ]
+        },
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Microservices',
+      collapsed: false,
+      items: [
+        'microservices/authorization/authorization-service',
+        'microservices/feedback/feedback-service',
+        'microservices/apps-service/apps-service',
+        'microservices/home/home-service',
+        {
+          type: 'category',
+          label: 'Notifications',
+          items: [
+            'microservices/notifications/notifications-service',
+            'microservices/notifications/notifications-get-started',
+          ]
+        },
+        'microservices/user-groups/user-groups-service',
+        'microservices/search/search-service',
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Component Library',
+      items: [
+        'components/component-library',
+        'documentation/styleguide',
+      ],
+    },
+    'cli/op-cli',
+    'faqs',
+  ],
 };

--- a/packages/home-spa/src/res/static/microservices.json
+++ b/packages/home-spa/src/res/static/microservices.json
@@ -2,37 +2,36 @@
     {
       "name": "Authentication",
       "description": "Adding authentication to your application is pice of cake. Just integrate with our API and focus on application development.",
-      "link": "/get-started/docs/microservices/authorization/authorization-service/",
+      "link": "/get-started/docs/microservices/authorization-service/",
       "icon": "res/img/auth.svg",
       "imgBgColor": "#F3FAF2"
     },
     {
       "name": "Feedback",
       "description": "Allows users to review and rate services and products provided by teams. Built into a power packed microservice so serve all.",
-      "link": "/get-started/docs/microservices/feedback/feedback-service/",
+      "link": "/get-started/docs/microservices/feedback-service/",
       "icon": "res/img/feedback.svg",
       "imgBgColor": "#FAEAE8"
     },
     {
       "name": "Notification",
       "description": "Notification framework for One Platform and also all other SPAs",
-      "link": "/get-started/docs/microservices/notifications/notifications-service/",
+      "link": "/get-started/docs/microservices/notifications-service/",
       "icon": "res/img/notification.svg",
       "imgBgColor": "#E7F1FA"
     },
     {
       "name": "User Group",
       "description": "A prebuilt integration with LDAP to authenticate, authorize and get user information.",
-      "link": "/get-started/docs/microservices/user-groups/user-groups-service/",
+      "link": "/get-started/docs/microservices/user-groups-service/",
       "icon": "res/img/user.svg",
       "imgBgColor": "#FDF7E7"
     },
     {
       "name": "Search",
       "description": "A unified search API gives you ability to search across all hosted applications on the platform.",
-      "link": "/get-started/docs/microservices/search/search-service/",
+      "link": "/get-started/docs/microservices/search-service/",
       "icon": "res/img/search.svg",
       "imgBgColor": "#F2F9F9"
     }
   ]
-  

--- a/packages/user-group-spa/src/App.jsx
+++ b/packages/user-group-spa/src/App.jsx
@@ -35,7 +35,7 @@ function App () {
     headerLinks.current.opcHeaderLinks = [
       {
         name: "Documentation",
-        href: "/get-started/docs/apps/internal/user-groups/user-groups-spa",
+        href: "/get-started/docs/apps/internal/user-groups",
         icon: 'fa-file'
       },
     ];


### PR DESCRIPTION
# Closes 1205

# Explain the feature/fix



## Does this PR introduce a breaking change

Yes. Some of the permalink to the documentation from other SPAs might be broken. I've tried to fix it wherever I could find the old links in home spa and user-group spa.

Need to check if any other SPA requires these changes.

## Screenshots

<details>
<summary>View Screenshots</summary>

| Label | Screenshot |
|---|---|
| Sidebar reordered | <img width="301" alt="Screenshot 2021-07-07 at 6 51 30 PM" src="https://user-images.githubusercontent.com/19623278/124766306-6df5bc00-df54-11eb-9e96-0c2d72a42d9a.png"> |
| Deprecation notice on Home Service | <img width="1364" alt="Screenshot 2021-07-07 at 6 50 37 PM" src="https://user-images.githubusercontent.com/19623278/124766450-9087d500-df54-11eb-96b8-7a2cd1b5405f.png"> |
| Apps Service Documentation | <img width="974" alt="Screenshot 2021-07-07 at 6 53 34 PM" src="https://user-images.githubusercontent.com/19623278/124766534-a4cbd200-df54-11eb-88d4-eb30f400dcca.png"> |

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
