### PR TITLE
Fixes broken links in documentation spa

### DIFF
--- a/packages/documentation-spa/docs/apps/internal/feedback/feedback-spa.md
+++ b/packages/documentation-spa/docs/apps/internal/feedback/feedback-spa.md
@@ -71,7 +71,7 @@ Feedback Application is the interface which have the view of the feedback & bug 
     ```
 
 ### API References
-Visit [Feedback Microservice](/docs/microservices/feedback/feedback-service) documentation for API references
+Visit [Feedback Microservice](/docs/microservices/feedback-service) documentation for API references
 ## FAQs
 
 <details>

--- a/packages/documentation-spa/docs/faqs.md
+++ b/packages/documentation-spa/docs/faqs.md
@@ -8,20 +8,20 @@ slug: /faqs
 
 ## Documentation FAQs
 
-1. [Documentation Style Guide](/docs/documentation/styleguide)
+1. [Documentation Style Guide](/docs/component-library/style-guide)
 
 ## Applications FAQs
 
 ### Hosted Apps
 
-1. [Research Repository](/docs/apps/hosted/research-repository/research-repository-spa#faqs)
+1. [Research Repository](/docs/apps/hosted/research-repository#faqs)
 
 ### Internal Apps
 
-1. [Feedback](/docs/apps/internal/feedback/feedback-spa#faqs)
-2. [Home](/docs/apps/internal/home/home-spa#faqs)
-3. [Notifications](/docs/apps/internal/notifications/notifications-spa#faqs)
-4. [SSI Service](/docs/apps/internal/ssi-service/ssi-service#faqs)
+1. [Feedback](/docs/apps/internal/feedback#faqs)
+2. [Home](/docs/apps/internal/home#faqs)
+3. [Notifications](/docs/apps/internal/notifications#faqs)
+4. [SSI Service](/docs/apps/internal/ssi#faqs)
 
 ### Assets
 
@@ -29,10 +29,10 @@ slug: /faqs
 
 ## CLI FAQs
 
-1. [OP CLI](/docs/cli/op-cli#faqs)
+1. [OP CLI](/docs/cli#faqs)
 
 ## Microservice FAQs
 
-1. [Feedback](/docs/microservices/feedback/feedback-service#faqs)
-2. [Home](/docs/microservices/home/home-service#faqs)
-3. [Notifications Service](/docs/microservices/notifications/notifications-service#faqs)
+1. [Feedback](/docs/microservices/feedback-service#faqs)
+2. [Home](/docs/microservices/apps-service#faqs)
+3. [Notifications Service](/docs/microservices/notifications-service#faqs)

--- a/packages/documentation-spa/docs/microservices/api-gateway/api-gateway.md
+++ b/packages/documentation-spa/docs/microservices/api-gateway/api-gateway.md
@@ -32,10 +32,10 @@ The API Gateway is basically a collection / entrypoint for the One Platform Micr
 
 The Microservices available via the API Gateway are:
 - [User & Groups](/get-started/docs/microservices/user-groups-service)
-- [Feedback Service](/get-started/microservices/feedback-service)
-- [Notifciations Service](/get-started/microservices/notifications-service)
-- [Search Service](/get-started/microservices/search-service)
-- [Apps Service](/get-started/microservices/apps-service)
+- [Feedback Service](/get-started/docs/microservices/feedback-service)
+- [Notifciations Service](/get-started/docs/microservices/notifications-service)
+- [Search Service](/get-started/docs/microservices/search-service)
+- [Apps Service](/get-started/docs/microservices/apps-service)
 
 ## Developers
 


### PR DESCRIPTION
# Fixes

Broken links in the documentation spa in pages:
- FAQs
- API Gateway
- Feedback SPA

## Does this PR introduce a breaking change

No.

## Screenshots

Error message during build:
<img width="1279" alt="Screenshot 2021-07-13 at 4 58 23 PM" src="https://user-images.githubusercontent.com/19623278/125444322-fc9434c5-dbce-44ff-8d9d-35d4de3bf498.png">

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
