### PR TITLE
feat(apps-service): Adds support for id in findApps and app query

### DIFF
--- a/packages/apps-service/src/modules/apps/model.ts
+++ b/packages/apps-service/src/modules/apps/model.ts
@@ -56,7 +56,7 @@ const AppSchema = new Schema<AppModel, AppModelStatic>( {
     feedbackEmail: { type: String, },
   },
   search: {
-    isActive: { type: Boolean, default: false, },
+    isEnabled: { type: Boolean, default: false, },
   },
   notifications: {
     isEnabled: { type: Boolean, default: false, },

--- a/packages/apps-service/src/modules/apps/resolver.ts
+++ b/packages/apps-service/src/modules/apps/resolver.ts
@@ -16,10 +16,13 @@ export default <IResolvers<App, IAppsContext>>{
       return Apps.find({ ownerId: rhatUUID }).exec();
     },
     findApps: ( parent, { selectors }, ctx ) => {
-      return Apps.find( selectors ).exec();
+      return Apps.find( {...selectors, _id: selectors.id } ).exec();
     },
-    app: ( parent, { appId } ) => {
-      return Apps.findOne( { appId } ).exec();
+    app: ( parent, { id, appId } ) => {
+      if ( !id && !appId ) {
+        throw new Error( 'Please provide atleast one argument for id or appId' );
+      }
+      return Apps.findOne( { appId, _id: id } ).exec();
     },
   },
   Mutation: {

--- a/packages/apps-service/src/modules/apps/schema.gql.ts
+++ b/packages/apps-service/src/modules/apps/schema.gql.ts
@@ -5,7 +5,7 @@ type Query {
   apps: [App]
   myApps: [App]
   findApps(selectors: FindAppInput!): [App]
-  app(appId: String!): App
+  app(id: ID, appId: String): App
 }
 type Mutation {
   createApp(app: CreateAppInput!): App

--- a/packages/apps-service/src/modules/microservices/resolver.ts
+++ b/packages/apps-service/src/modules/microservices/resolver.ts
@@ -16,10 +16,13 @@ export default <IResolvers<Microservice, IAppsContext>>{
       return Microservices.find( { ownerId: rhatUUID } ).exec();
     },
     findServices: ( parent, { selectors }, ctx ) => {
-      return Microservices.find( selectors ).exec();
+      return Microservices.find( { ...selectors, _id: selectors.id } ).exec();
     },
-    service: ( parent, { serviceId }, { rhatUUID } ) => {
-      return Microservices.findOne( { serviceId } ).exec();
+    service: ( parent, { id, serviceId }, { rhatUUID } ) => {
+      if ( !id && !serviceId ) {
+        throw new Error( 'Please provide atleast one argument for id or serviceId' );
+      }
+      return Microservices.findOne( { serviceId, _id: id } ).exec();
     },
   },
   Mutation: {

--- a/packages/apps-service/src/modules/microservices/schema.gql.ts
+++ b/packages/apps-service/src/modules/microservices/schema.gql.ts
@@ -5,7 +5,7 @@ type Query {
   services: [Service]
   myServices: [Service]
   findServices(selectors: FindServicesInput!): [Service]
-  service(serviceId: String!): Service
+  service(id: ID, serviceId: String): Service
 }
 
 type Mutation {
@@ -36,6 +36,7 @@ type AppPermissions {
 }
 
 input FindServicesInput {
+  id: ID
   serviceId: String
   name: String
   isActive: Boolean


### PR DESCRIPTION
# Closes 1257

# Explain the feature/fix

- Added support to query by `id` in the `findApps`, `app`, `findService` and `service` queries

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
