### PR TITLE
fix(apps-service): Handled null value for id in apps service

### DIFF
--- a/packages/apps-service/src/modules/apps/resolver.ts
+++ b/packages/apps-service/src/modules/apps/resolver.ts
@@ -16,13 +16,22 @@ export default <IResolvers<App, IAppsContext>>{
       return Apps.find({ ownerId: rhatUUID }).exec();
     },
     findApps: ( parent, { selectors }, ctx ) => {
-      return Apps.find( {...selectors, _id: selectors.id } ).exec();
+      const _id = selectors.id;
+      delete selectors.id;
+
+      return Apps.find( {
+        ...selectors,
+        ...( _id && { _id } ),
+      } ).exec();
     },
     app: ( parent, { id, appId } ) => {
       if ( !id && !appId ) {
         throw new Error( 'Please provide atleast one argument for id or appId' );
       }
-      return Apps.findOne( { appId, _id: id } ).exec();
+      return Apps.findOne( {
+        ...( appId && { appId } ),
+        ...( id && { _id: id } ),
+      } ).exec();
     },
   },
   Mutation: {

--- a/packages/apps-service/src/modules/microservices/resolver.ts
+++ b/packages/apps-service/src/modules/microservices/resolver.ts
@@ -16,13 +16,22 @@ export default <IResolvers<Microservice, IAppsContext>>{
       return Microservices.find( { ownerId: rhatUUID } ).exec();
     },
     findServices: ( parent, { selectors }, ctx ) => {
-      return Microservices.find( { ...selectors, _id: selectors.id } ).exec();
+      const _id = selectors.id;
+      delete selectors.id;
+
+      return Microservices.find( {
+        ...selectors,
+        ...( _id && { _id } ),
+      } ).exec();
     },
     service: ( parent, { id, serviceId }, { rhatUUID } ) => {
       if ( !id && !serviceId ) {
         throw new Error( 'Please provide atleast one argument for id or serviceId' );
       }
-      return Microservices.findOne( { serviceId, _id: id } ).exec();
+      return Microservices.findOne( {
+        ...( serviceId && { serviceId } ),
+        ...( id && { _id: id } ),
+      } ).exec();
     },
   },
   Mutation: {


### PR DESCRIPTION
# Fixes

The `app` and `findApps` queries broke functionality for null value of `id` field.

# Explain the feature/fix

Handled the null value by adding extra checks.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
