### PR TITLE
(hotfix:lh-image) - Rolling back the changes on github image because dependency installation scope is different

### DIFF
--- a/packages/lighthouse-service/Dockerfile
+++ b/packages/lighthouse-service/Dockerfile
@@ -7,7 +7,6 @@ LABEL Name=one-platform-lighthouse-service \
 ADD  . /app
 WORKDIR /app
 
-ENV NPM_CONFIG_PREFIX=/app/.npm-global
 RUN npm install -g @lhci/cli && \
   npm install --silent && \
   npm run build


### PR DESCRIPTION
# Explain the fix
Installation of lhci fails on image with the NPM_CONFIG_PREFIX param which led to workflow failure while testing docker. For now i am rolling back the change. 

## Does this PR introduce a breaking change

No

## Screenshots
N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?