### PR TITLE
chore(api-gateway): Adds configurability for API Gateway Base URL

### DIFF
--- a/packages/api-gateway-service/.env.example
+++ b/packages/api-gateway-service/.env.example
@@ -2,6 +2,10 @@
 
 NODE_ENV=
 
+## API Gateway Base Path (Optional, the following values are considered default)
+# BASE_URL=/
+# SUBSCRIPTIONS_BASE_URL=/subscriptions
+
 ## Microservice Config
 CONFIG_PATH=
 

--- a/packages/api-gateway-service/src/remote-schema.ts
+++ b/packages/api-gateway-service/src/remote-schema.ts
@@ -31,9 +31,6 @@ function getSubscriber ( url: string, serviceName: string ): Subscriber {
         connectionParams: {
           'X-OP-User-ID': context?.uid,
           'From': 'OP-API-GATEWAY',
-        },
-        connectionCallback: ( err, res ) => {
-          console.log( err, res );
         }
       },
       ws


### PR DESCRIPTION
# Closes ONEPLAT-1346

# Explain the feature/fix

Adds an environment variable for easy configuration of the Base path of the GraphQL API Gateway and its subscriptions URL.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
- [x] Was this feature demo'd and the design review approved?
