### PR TITLE
fix(dev-console): Fixes scroll overflow in dev console sidebar

### DIFF
--- a/packages/developer-console-spa/src/components/Sidebar.css
+++ b/packages/developer-console-spa/src/components/Sidebar.css
@@ -4,6 +4,8 @@
   display: flex;
   flex-direction: column;
   max-width: 300px;
+  position: sticky;
+  top: var(--op-nav__height);
 }
 .app-menu--list {
   margin: .25rem;
@@ -32,11 +34,16 @@
 }
 
 .app-details--sidebar--main-nav {
-  flex: 1 0 auto;
+  flex: 1 0;
+  overflow-y: auto;
 }
 .app-details--sidebar--title {
   margin-top: 1rem;
   margin-bottom: .25rem;
+  position: sticky;
+  top: -.25rem;
+  background: #fff;
+  z-index: 1;
 }
 .app-details--sidebar--settings {
   position: relative;


### PR DESCRIPTION
# Fixes 1426

# Explain the feature/fix

Added `position: sticky` and `overflow-y` to the sidebar and the menu_list to the sidebar on the developer console to accomodate overflowing content inside the sidebar, as well as outside.

## Does this PR introduce a breaking change

N/A

## Screenshots

<details>
<summary>View Screenshots</summary>

<img width="1241" alt="Screenshot 2021-08-18 at 4 01 33 PM" src="https://user-images.githubusercontent.com/19623278/129883408-4f7b2285-5ab4-430c-94b2-727c860c3f3e.png">

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
