### PR TITLE
fix(renovate): Fixes the renovate config schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:base", ":semanticCommits"],
-  "schedule": "every month on the last monday of the month",
+  "schedule": "first day of the month",
   "packageRules": [
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
Fixes the incorrect syntax for renovate schedule in the config.

Created from github.dev