### PR TITLE
Fixes the schedule syntax in renovate as per breejs/later format

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:base", ":semanticCommits"],
-  "schedule": "first day of the month",
+  "schedule": "on the first day of the month",
   "packageRules": [
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
The syntax for schedule had an error. Fixed and verified it this time with the @breejs/later format

Created from github.dev