### PR TITLE
Adds user prefix in the userCtx role for couchdb

### DIFF
--- a/packages/reverse-proxy-service/src/couchdb/resolver.ts
+++ b/packages/reverse-proxy-service/src/couchdb/resolver.ts
@@ -9,7 +9,11 @@ export default function resolver ( req: Request, res: Response, next: NextFuncti
   const { uid, role, rhatUUID } = res.locals.user;
 
   /* Adding additional roles */
-  role.push( uid, rhatUUID, 'op-user' );
+  role.push(
+    'user:' + uid,
+    'user:' + rhatUUID,
+    'op-users'
+  );
 
   const token = createHmac( 'sha1', COUCHDB_SECRET as string ).update( uid ).digest( 'hex' );
 


### PR DESCRIPTION
# Explain the feature/fix

Added a `user:` prefix to the uid roles in the couchdb middleware in reverse-proxy.
This allows the devs to identify between a uid and a group in the userCtx roles for better authorization in couchdb.

## Does this PR introduce a breaking change

Yes.

Any existing apps that rely on the userCtx roles for authorization will have to change the way they check the user roles for auth.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
- [x] Was this feature demo'd and the design review approved?
