### PR TITLE
chore(docker-compose): Added couchdb service to the main docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,14 @@ services:
     env_file: ./packages/reverse-proxy-service/.env
     environment:
       PORT: 8000
+      COUCHDB_HOST: http://couchdb:5984
+      COUCHDB_SECRET: couchdbsecret123                # as defined in the couchdb service environment
     volumes:
       - ./packages/reverse-proxy-service:/usr/src
     ports:
       - 8000:8000
+    depends_on:
+      - couchdb
 
   api-gateway:
     build: ./packages/api-gateway-service
@@ -54,12 +58,15 @@ services:
     command: npm start
     environment:
       MONGO_URL: mongodb://mongo:27017/apps-service
+      COUCHDB_ENDPOINT: http://couchdb:5984
+      COUCHDB_ADMIN_TOKEN: "<add admin token to test couchdb integration>"   # Basic <base64 of COUCHDB_USER:COUCHDB_PASSWORD>
     volumes:
       - ./packages/apps-service:/usr/src
     ports:
       - 8081:8080
     depends_on:
       - mongo
+      - couchdb
 
   feedback-service:
     build: ./packages/feedback-service
@@ -163,6 +170,21 @@ services:
     ports:
       - 37017:27017
 
+  couchdb:
+    image: couchdb:3
+    environment:
+      COUCHDB_USER: couchdb
+      # since this is a local development instance, it should be okay to keep the defaut values,
+      # but the password can be changed from the couchdb fauxton ui.
+      # Just make sure to update the password in the dependent service .env's
+      COUCHDB_PASSWORD: test123
+      COUCHDB_SECRET: couchdbsecret123
+    volumes:
+      - couch_data:/opt/couchdb/data
+      - couch_config:/opt/couchdb/etc/local.d
+    ports:
+      - 5984:5984
+
   redis:
     image: redis:alpine
     ports:
@@ -170,3 +192,7 @@ services:
     restart: on-failure
     logging:
       driver: none
+
+volumes:
+  couch_data:
+  couch_config:


### PR DESCRIPTION
# Explain the feature/fix

Added the couchdb as a service to the main `docker-compose.yml`.
It is a dependency of the reverse-proxy-service and the apps-service.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
