### PR TITLE
fix(1602): implemented stricter url validation in report generation page

### DIFF
--- a/packages/lighthouse-spa/package-lock.json
+++ b/packages/lighthouse-spa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-spa",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2114,9 +2114,9 @@
       }
     },
     "@one-platform/opc-base": {
-      "version": "1.0.4-beta",
-      "resolved": "https://registry.npmjs.org/@one-platform/opc-base/-/opc-base-1.0.4-beta.tgz",
-      "integrity": "sha512-EXs5nqTtPgpa6HtZA3Y/lf/uByqC/JWZ1ktOD39Z9l8oc8t2zCecdlgxe+9FxnyWzQcXKCHfO0D0axyieKXbsA==",
+      "version": "1.0.5-beta",
+      "resolved": "https://registry.npmjs.org/@one-platform/opc-base/-/opc-base-1.0.5-beta.tgz",
+      "integrity": "sha512-qX/O/+L4szAYJg5dXzZsBClRLayo4LqC//MjdfE5TUjKVhRwfNmo8joV3cn486lTyDLsW5r3sdjgcB/A8Gv2Vg==",
       "requires": {
         "@apollo/client": "^3.3.21",
         "@patternfly/pfe-toast": "^1.10.1",
@@ -2160,9 +2160,9 @@
           }
         },
         "graphql": {
-          "version": "15.6.1",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.1.tgz",
-          "integrity": "sha512-3i5lu0z6dRvJ48QP9kFxBkJ7h4Kso7PS8eahyTFz5Jm6CvQfLtNIE8LX9N6JLnXTuwR+sIYnXzaWp6anOg0QQw=="
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+          "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A=="
         },
         "subscriptions-transport-ws": {
           "version": "0.9.19",
@@ -2395,9 +2395,9 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
     "@trysound/sax": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
-      "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "dev": true
     },
     "@types/babel__core": {
@@ -2988,9 +2988,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -4308,6 +4308,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "colord": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.1.tgz",
+      "integrity": "sha512-4LBMSt09vR0uLnPVkOUBnmxgoaeN4ewRbx801wY/bXcltXfpR/G46OdWn96XpYmCWuYvO46aBZP4NgX8HpNAcw==",
+      "dev": true
+    },
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -4794,9 +4800,9 @@
       "dev": true
     },
     "css-declaration-sorter": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.0.3.tgz",
-      "integrity": "sha512-52P95mvW1SMzuRZegvpluT6yEv0FqQusydKQPZsNN5Q7hh8EwQvN8E2nwuJ16BBvNN6LcoIZXu/Bk58DAhrrxw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.3.tgz",
+      "integrity": "sha512-SvjQjNRZgh4ULK1LDJ2AduPKUKxIqmtU7ZAyi47BTV+M90Qvxr9AB6lKlLbDUfXqI9IQeYA8LbAsCZPpJEV3aA==",
       "dev": true,
       "requires": {
         "timsort": "^0.3.0"
@@ -4864,19 +4870,6 @@
         }
       }
     },
-    "css-select": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
-      "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
-      "dev": true,
-      "requires": {
-        "boolbase": "^1.0.0",
-        "css-what": "^4.0.0",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.4.3",
-        "nth-check": "^2.0.0"
-      }
-    },
     "css-selector-tokenizer": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
@@ -4896,12 +4889,6 @@
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
       }
-    },
-    "css-what": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
-      "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
-      "dev": true
     },
     "cssauron": {
       "version": "1.4.0",
@@ -4930,24 +4917,24 @@
       }
     },
     "cssnano-preset-default": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.3.tgz",
-      "integrity": "sha512-qo9tX+t4yAAZ/yagVV3b+QBKeLklQbmgR3wI7mccrDcR+bEk9iHgZN1E7doX68y9ThznLya3RDmR+nc7l6/2WQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.6.tgz",
+      "integrity": "sha512-X2nDeNGBXc0486oHjT2vSj+TdeyVsxRvJUxaOH50hOM6vSDLkKd0+59YXpSZRInJ4sNtBOykS4KsPfhdrU/35w==",
       "dev": true,
       "requires": {
         "css-declaration-sorter": "^6.0.3",
         "cssnano-utils": "^2.0.1",
         "postcss-calc": "^8.0.0",
-        "postcss-colormin": "^5.2.0",
-        "postcss-convert-values": "^5.0.1",
+        "postcss-colormin": "^5.2.1",
+        "postcss-convert-values": "^5.0.2",
         "postcss-discard-comments": "^5.0.1",
         "postcss-discard-duplicates": "^5.0.1",
         "postcss-discard-empty": "^5.0.1",
         "postcss-discard-overridden": "^5.0.1",
-        "postcss-merge-longhand": "^5.0.2",
+        "postcss-merge-longhand": "^5.0.3",
         "postcss-merge-rules": "^5.0.2",
         "postcss-minify-font-values": "^5.0.1",
-        "postcss-minify-gradients": "^5.0.1",
+        "postcss-minify-gradients": "^5.0.3",
         "postcss-minify-params": "^5.0.1",
         "postcss-minify-selectors": "^5.1.0",
         "postcss-normalize-charset": "^5.0.1",
@@ -4962,78 +4949,8 @@
         "postcss-ordered-values": "^5.0.2",
         "postcss-reduce-initial": "^5.0.1",
         "postcss-reduce-transforms": "^5.0.1",
-        "postcss-svgo": "^5.0.2",
+        "postcss-svgo": "^5.0.3",
         "postcss-unique-selectors": "^5.0.1"
-      },
-      "dependencies": {
-        "colord": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/colord/-/colord-2.6.0.tgz",
-          "integrity": "sha512-8yMrtE20ZxH1YWvvSoeJFtvqY+GIAOfU+mZ3jx7ZSiEMasnAmNqD1BKUP3CuCWcy/XHgcXkLW6YU8C35nhOYVg==",
-          "dev": true
-        },
-        "normalize-url": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-          "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-          "dev": true
-        },
-        "postcss-colormin": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.2.0.tgz",
-          "integrity": "sha512-+HC6GfWU3upe5/mqmxuqYZ9B2Wl4lcoUUNkoaX59nEWV4EtADCMiBqui111Bu8R8IvaZTmqmxrqOAqjbHIwXPw==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.16.6",
-            "caniuse-api": "^3.0.0",
-            "colord": "^2.0.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-merge-rules": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.0.2.tgz",
-          "integrity": "sha512-5K+Md7S3GwBewfB4rjDeol6V/RZ8S+v4B66Zk2gChRqLTCC8yjnHQ601omj9TKftS19OPGqZ/XzoqpzNQQLwbg==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.16.6",
-            "caniuse-api": "^3.0.0",
-            "cssnano-utils": "^2.0.1",
-            "postcss-selector-parser": "^6.0.5",
-            "vendors": "^1.0.3"
-          }
-        },
-        "postcss-normalize-url": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.2.tgz",
-          "integrity": "sha512-k4jLTPUxREQ5bpajFQZpx8bCF2UrlqOTzP9kEqcEnOfwsRshWs2+oAFIHfDQB8GO2PaUaSE0NlTAYtbluZTlHQ==",
-          "dev": true,
-          "requires": {
-            "is-absolute-url": "^3.0.3",
-            "normalize-url": "^6.0.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-ordered-values": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.2.tgz",
-          "integrity": "sha512-8AFYDSOYWebJYLyJi3fyjl6CqMEG/UVworjiyK1r573I56kb3e879sCJLGvR3merj+fAdPpVplXKQZv+ey6CgQ==",
-          "dev": true,
-          "requires": {
-            "cssnano-utils": "^2.0.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-svgo": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.0.2.tgz",
-          "integrity": "sha512-YzQuFLZu3U3aheizD+B1joQ94vzPfE6BNUcSYuceNxlVnKKsOtdo6hL9/zyC168Q8EwfLSgaDSalsUGa9f2C0A==",
-          "dev": true,
-          "requires": {
-            "postcss-value-parser": "^4.1.0",
-            "svgo": "^2.3.0"
-          }
-        }
       }
     },
     "cssnano-utils": {
@@ -6895,12 +6812,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hex-color-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
-      "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
-      "dev": true
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6962,18 +6873,6 @@
           }
         }
       }
-    },
-    "hsl-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
-      "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
-      "dev": true
-    },
-    "hsla-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
-      "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
-      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -7449,28 +7348,6 @@
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "requires": {
         "ci-info": "^2.0.0"
-      }
-    },
-    "is-color-stop": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
-      "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
-      "dev": true,
-      "requires": {
-        "css-color-names": "^0.0.4",
-        "hex-color-regex": "^1.1.0",
-        "hsl-regex": "^1.0.0",
-        "hsla-regex": "^1.0.0",
-        "rgb-regex": "^1.0.1",
-        "rgba-regex": "^1.0.0"
-      },
-      "dependencies": {
-        "css-color-names": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-          "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
-          "dev": true
-        }
       }
     },
     "is-core-module": {
@@ -9923,6 +9800,12 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
+    "normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true
+    },
     "npm-bundled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
@@ -10029,9 +9912,9 @@
       }
     },
     "nth-check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
@@ -10524,6 +10407,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -10632,10 +10521,22 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
+    "postcss-colormin": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.2.1.tgz",
+      "integrity": "sha512-VVwMrEYLcHYePUYV99Ymuoi7WhKrMGy/V9/kTS0DkCoJYmmjdOMneyhzYUxcNgteKDVbrewOkSM7Wje/MFwxzA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.16.6",
+        "caniuse-api": "^3.0.0",
+        "colord": "^2.9.1",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
     "postcss-convert-values": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.0.1.tgz",
-      "integrity": "sha512-C3zR1Do2BkKkCgC0g3sF8TS0koF2G+mN8xxayZx3f10cIRmTaAnpgpRQZjNekTZxM2ciSPoh2IWJm0VZx8NoQg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.0.2.tgz",
+      "integrity": "sha512-KQ04E2yadmfa1LqXm7UIDwW1ftxU/QWZmz6NKnHnUvJ3LEYbbcX6i329f/ig+WnEByHegulocXrECaZGLpL8Zg==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.1.0"
@@ -10703,14 +10604,27 @@
       }
     },
     "postcss-merge-longhand": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.0.2.tgz",
-      "integrity": "sha512-BMlg9AXSI5G9TBT0Lo/H3PfUy63P84rVz3BjCFE9e9Y9RXQZD3+h3YO1kgTNsNJy7bBc1YQp8DmSnwLIW5VPcw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.0.3.tgz",
+      "integrity": "sha512-kmB+1TjMTj/bPw6MCDUiqSA5e/x4fvLffiAdthra3a0m2/IjTrWsTmD3FdSskzUjEwkj5ZHBDEbv5dOcqD7CMQ==",
       "dev": true,
       "requires": {
         "css-color-names": "^1.0.1",
         "postcss-value-parser": "^4.1.0",
         "stylehacks": "^5.0.1"
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.0.2.tgz",
+      "integrity": "sha512-5K+Md7S3GwBewfB4rjDeol6V/RZ8S+v4B66Zk2gChRqLTCC8yjnHQ601omj9TKftS19OPGqZ/XzoqpzNQQLwbg==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.16.6",
+        "caniuse-api": "^3.0.0",
+        "cssnano-utils": "^2.0.1",
+        "postcss-selector-parser": "^6.0.5",
+        "vendors": "^1.0.3"
       }
     },
     "postcss-minify-font-values": {
@@ -10723,13 +10637,13 @@
       }
     },
     "postcss-minify-gradients": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.1.tgz",
-      "integrity": "sha512-odOwBFAIn2wIv+XYRpoN2hUV3pPQlgbJ10XeXPq8UY2N+9ZG42xu45lTn/g9zZ+d70NKSQD6EOi6UiCMu3FN7g==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.3.tgz",
+      "integrity": "sha512-Z91Ol22nB6XJW+5oe31+YxRsYooxOdFKcbOqY/V8Fxse1Y3vqlNRpi1cxCqoACZTQEhl+xvt4hsbWiV5R+XI9Q==",
       "dev": true,
       "requires": {
+        "colord": "^2.9.1",
         "cssnano-utils": "^2.0.1",
-        "is-color-stop": "^1.1.0",
         "postcss-value-parser": "^4.1.0"
       }
     },
@@ -10855,12 +10769,33 @@
         "postcss-value-parser": "^4.1.0"
       }
     },
+    "postcss-normalize-url": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.2.tgz",
+      "integrity": "sha512-k4jLTPUxREQ5bpajFQZpx8bCF2UrlqOTzP9kEqcEnOfwsRshWs2+oAFIHfDQB8GO2PaUaSE0NlTAYtbluZTlHQ==",
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "^3.0.3",
+        "normalize-url": "^6.0.1",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
     "postcss-normalize-whitespace": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.1.tgz",
       "integrity": "sha512-iPklmI5SBnRvwceb/XH568yyzK0qRVuAG+a1HFUsFRf11lEJTiQQa03a4RSCQvLKdcpX7XsI1Gen9LuLoqwiqA==",
       "dev": true,
       "requires": {
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.2.tgz",
+      "integrity": "sha512-8AFYDSOYWebJYLyJi3fyjl6CqMEG/UVworjiyK1r573I56kb3e879sCJLGvR3merj+fAdPpVplXKQZv+ey6CgQ==",
+      "dev": true,
+      "requires": {
+        "cssnano-utils": "^2.0.1",
         "postcss-value-parser": "^4.1.0"
       }
     },
@@ -10892,6 +10827,16 @@
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-svgo": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.0.3.tgz",
+      "integrity": "sha512-41XZUA1wNDAZrQ3XgWREL/M2zSw8LJPvb5ZWivljBsUQAGoEKMYm6okHsTjJxKYI4M75RQEH4KYlEM52VwdXVA==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.1.0",
+        "svgo": "^2.7.0"
       }
     },
     "postcss-unique-selectors": {
@@ -11812,18 +11757,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "dev": true
-    },
-    "rgb-regex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
-      "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
-      "dev": true
-    },
-    "rgba-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
-      "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
     },
     "rimraf": {
@@ -13221,18 +13154,39 @@
       }
     },
     "svgo": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.0.tgz",
-      "integrity": "sha512-fz4IKjNO6HDPgIQxu4IxwtubtbSfGEAJUq/IXyTPIkGhWck/faiiwfkvsB8LnBkKLvSoyNNIY6d13lZprJMc9Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
       "dev": true,
       "requires": {
-        "@trysound/sax": "0.1.1",
-        "chalk": "^4.1.0",
-        "commander": "^7.1.0",
-        "css-select": "^3.1.2",
-        "css-tree": "^1.1.2",
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^4.1.3",
+        "css-tree": "^1.1.3",
         "csso": "^4.2.0",
+        "picocolors": "^1.0.0",
         "stable": "^0.1.8"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+          "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
+          "dev": true,
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^5.0.0",
+            "domhandler": "^4.2.0",
+            "domutils": "^2.6.0",
+            "nth-check": "^2.0.0"
+          }
+        },
+        "css-what": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+          "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
+          "dev": true
+        }
       }
     },
     "symbol-observable": {
@@ -13442,9 +13396,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -15590,45 +15544,12 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "wildcard": {

--- a/packages/lighthouse-spa/package.json
+++ b/packages/lighthouse-spa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-spa",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -27,7 +27,7 @@
     "@angular/platform-browser-dynamic": "11.2.14",
     "@angular/router": "11.2.14",
     "@apollo/client": "3.3.19",
-    "@one-platform/opc-base": "^1.0.4-beta",
+    "@one-platform/opc-base": "^1.0.5-beta",
     "@one-platform/opc-feedback": "0.0.9-prerelease",
     "@one-platform/opc-footer": "0.0.3-prerelease",
     "@one-platform/opc-menu-drawer": "^0.1.2-prerelease",

--- a/packages/lighthouse-spa/src/app/dashboard/pages/home/home.component.html
+++ b/packages/lighthouse-spa/src/app/dashboard/pages/home/home.component.html
@@ -22,9 +22,9 @@
             (ngSubmit)="SearchForm.form.valid && navigateToReportGeneration()">
             <div class="pf-l-stack__item pf-l-flex pf-m-nowrap pf-m-justify-content-center">
                 <div class="pf-c-input-group pf-u-w-33 pf-u-mr-md">
-                    <input class="pf-c-form-control pf-m-search lighthouse-search" type="search" id="sites" name="sites"
+                    <input class="pf-c-form-control pf-m-search lighthouse-search" type="url" id="sites" name="sites"
                         aria-label="Enter webpage url" placeholder="Enter web page url with http/https"
-                        [(ngModel)]="sites" pattern="^https?:\/\/(.*)" required />
+                        [(ngModel)]="sites" required urlValidator />
                 </div>
                 <div>
                     <button class="pf-c-button pf-m-progress pf-m-primary" type="submit"

--- a/packages/lighthouse-spa/src/app/playground/components/home/home.component.html
+++ b/packages/lighthouse-spa/src/app/playground/components/home/home.component.html
@@ -7,9 +7,9 @@
             </div>
             <div class="pf-l-stack__item pf-l-flex pf-m-nowrap pf-m-justify-content-center">
                 <div class="pf-c-input-group pf-u-w-33 pf-u-mr-md">
-                    <input class="pf-c-form-control pf-m-search lighthouse-search" type="search" id="sites" name="sites"
+                    <input class="pf-c-form-control pf-m-search lighthouse-search" type="url" id="sites" name="sites"
                         aria-label="Enter webpage url" placeholder="Enter web page url with http/https"
-                        [(ngModel)]="sites" pattern="^https?:\/\/(.*)" required />
+                        [(ngModel)]="sites" required urlValidator />
                 </div>
                 <div>
                     <button class="pf-c-button pf-m-progress pf-m-primary" type="submit"

--- a/packages/lighthouse-spa/src/app/shared/directive/url-validator.directive.spec.ts
+++ b/packages/lighthouse-spa/src/app/shared/directive/url-validator.directive.spec.ts
@@ -1,0 +1,8 @@
+import { UrlValidatorDirective } from './url-validator.directive';
+
+describe('UrlValidatorDirective', () => {
+  it('should create an instance', () => {
+    const directive = new UrlValidatorDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/packages/lighthouse-spa/src/app/shared/directive/url-validator.directive.ts
+++ b/packages/lighthouse-spa/src/app/shared/directive/url-validator.directive.ts
@@ -1,0 +1,31 @@
+import { Directive } from '@angular/core';
+import { FormControl, NG_VALIDATORS, ValidatorFn } from '@angular/forms';
+
+@Directive({
+  selector: '[urlValidator][ngModel]',
+  providers: [
+    { provide: NG_VALIDATORS, useExisting: UrlValidatorDirective, multi: true },
+  ],
+})
+export class UrlValidatorDirective {
+  validator: ValidatorFn;
+  constructor() {
+    this.validator = this.urlValidator();
+  }
+
+  validate(c: FormControl) {
+    return this.validator(c);
+  }
+
+  urlValidator(): ValidatorFn {
+    return (control: FormControl) => {
+      const url = control.value;
+      try {
+        new URL(url);
+        return null;
+      } catch (e) {
+        return { urlValidator: { valid: false } };
+      }
+    };
+  }
+}

--- a/packages/lighthouse-spa/src/app/shared/shared.module.ts
+++ b/packages/lighthouse-spa/src/app/shared/shared.module.ts
@@ -13,6 +13,7 @@ import { ContextSelectorComponent } from './components/context-selector/context-
 
 import { LHScoreLabelFormaterPipe } from './pipes/lhscore-label-formater.pipe';
 import { FilterListPipe } from './pipes/filter-list.pipe';
+import { UrlValidatorDirective } from './directive/url-validator.directive';
 
 @NgModule({
   declarations: [
@@ -25,6 +26,7 @@ import { FilterListPipe } from './pipes/filter-list.pipe';
     LHScoreLabelFormaterPipe,
     FilterListPipe,
     ContextSelectorComponent,
+    UrlValidatorDirective,
   ],
   imports: [CommonModule, RouterModule],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -38,6 +40,7 @@ import { FilterListPipe } from './pipes/filter-list.pipe';
     LHScoreLabelFormaterPipe,
     FilterListPipe,
     ContextSelectorComponent,
+    UrlValidatorDirective,
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
# Fixes

1602

# Explain the feature/fix

1. Implemented stricter url validation for report generation
2. Update opc-base to latest version

## Does this PR introduce a breaking change

No

## Screenshots

<details>
<summary>View Screenshots</summary>

## Invalid URL

![Screenshot 2021-11-08 at 12 25 07 PM](https://user-images.githubusercontent.com/31166322/140699986-5c2ecdfd-c9db-412b-9946-9aa26af053ce.png)

## Valid URL

![Screenshot 2021-11-08 at 12 25 14 PM](https://user-images.githubusercontent.com/31166322/140699942-f85234f4-1e50-4dee-bd1a-c3238396cafd.png)

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
