### PR TITLE
fix: opc-base chrome error and subscription variable fix

### DIFF
--- a/packages/opc-base/package-lock.json
+++ b/packages/opc-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@one-platform/opc-base",
-  "version": "1.1.0-beta",
+  "version": "1.1.1-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opc-base/package.json
+++ b/packages/opc-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@one-platform/opc-base",
-  "version": "1.1.0-beta",
+  "version": "1.1.1-beta",
   "description": "It contains shared components like layout, authentication provider for one platform",
   "main": "dist/opc-base.js",
   "module": "dist/opc-base.js",

--- a/packages/opc-base/src/config/graphql.ts
+++ b/packages/opc-base/src/config/graphql.ts
@@ -46,7 +46,6 @@ export class APIService {
    */
   get _headers() {
     return {
-      "Content-Type": "application/json",
       Authorization: window.OpAuthHelper?.jwtToken
         ? "Bearer " + window.OpAuthHelper.jwtToken
         : "",

--- a/packages/opc-base/src/opc-provider/opc-provider.ts
+++ b/packages/opc-base/src/opc-provider/opc-provider.ts
@@ -26,8 +26,9 @@ import {
   CreateFeedback,
   CreateFeedbackVariable,
   GetAppList,
+  SubscribeNotification,
 } from "../gql/types";
-import { subscriptionT } from 'wonka/dist/types/src/Wonka_types.gen';
+import { subscriptionT } from "wonka/dist/types/src/Wonka_types.gen";
 
 import { APIService } from "../config/graphql";
 
@@ -303,7 +304,7 @@ export class OpcProvider extends LitElement {
         })
         .toPromise();
 
-      if ( !res?.data ) return;
+      if (!res?.data) return;
 
       this.apps =
         res.data.appsList
@@ -353,7 +354,10 @@ export class OpcProvider extends LitElement {
       }
 
       this._notificationsSubscription = pipe(
-        this.api.gqlClient.subscription(SUBSCRIBE_NOTIFICATION),
+        this.api.gqlClient.subscription<
+          SubscribeNotification,
+          { targets: string[] }
+        >(SUBSCRIBE_NOTIFICATION, { targets: userDetails }),
         subscribe((res) => {
           if (res.error) {
             throw res.error;


### PR DESCRIPTION
# Closes/Fixes/Resolves

# Explain the feature/fix

1. Fixed notification subscription missing target variable
2. Fixed chrome server error

The issue was, the header `content-type: application/json`. From previous code for apollo it was explicitly given in which URQL cases it's not needed. In firefox header was passed as it is. But in chrome when the header was given it appends to that header  causing `content-type: application/json, application/json` failing the server operation.

FIx was just removing that explicit header and letting urql handle it by itself.

## Does this PR introduce a breaking change

No

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

## Mozilla

![Screenshot 2021-11-08 at 2 28 48 PM](https://user-images.githubusercontent.com/31166322/140714776-ba6c2ee5-1b7d-4b61-ac43-275a99997c31.png)


## Chrome

![Screenshot 2021-11-08 at 2 27 46 PM](https://user-images.githubusercontent.com/31166322/140714809-47aade72-7cf6-455e-9580-c2b2843148ce.png)


</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
