### PR TITLE
feat: opc-base changed to warning on mutating config values

### DIFF
--- a/packages/opc-base/docs/opc-base.md
+++ b/packages/opc-base/docs/opc-base.md
@@ -63,6 +63,7 @@ Object properties
 - keycloakClientId: keycloak client id
 - keycloakRealm: keycloak clock realm
 - cachePolicy (optional): The fetch policy strategy followed by the graphql instance([urql](https://formidable.com/open-source/urql/)) used in opc-base. By default `cache-first`
+- isDebugMode (optional): Setting debug mode as true enables to log warnings. Used in development to show warning when mutating opcBase values. By default false.
 
 ###### opcBase.auth
 

--- a/packages/opc-base/package-lock.json
+++ b/packages/opc-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@one-platform/opc-base",
-  "version": "1.1.1-beta",
+  "version": "1.1.2-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opc-base/package.json
+++ b/packages/opc-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@one-platform/opc-base",
-  "version": "1.1.1-beta",
+  "version": "1.1.2-beta",
   "description": "It contains shared components like layout, authentication provider for one platform",
   "main": "dist/opc-base.js",
   "module": "dist/opc-base.js",

--- a/packages/opc-base/src/opc-base/opc-base.ts
+++ b/packages/opc-base/src/opc-base/opc-base.ts
@@ -1,4 +1,4 @@
-import { Client } from '@urql/core';
+import { Client } from "@urql/core";
 import { OpKeycloakAuthProvider } from "../keycloakAuthProvider/keycloakAuthProvider";
 import { OpcBase as OpcBaseType, Config, Toast, Feedback } from "./types";
 
@@ -34,10 +34,11 @@ class OpcBase {
   }
 
   set toast(toast: Toast) {
-    if (this._app.toast) {
-      throw new Error("Cannot set toast");
+    if (!this._app.toast) {
+      this._app.toast = toast;
+    } else {
+      this._app.config?.isDebugMode && console.warn("Cannot set toast");
     }
-    this._app.toast = toast;
   }
 
   get toast() {
@@ -46,10 +47,11 @@ class OpcBase {
   }
 
   set feedback(feedback: Feedback) {
-    if (this._app.feedback) {
-      throw new Error("Cannot set feedback");
+    if (!this._app.feedback) {
+      this._app.feedback = feedback;
+    } else {
+      this._app.config?.isDebugMode && console.warn("Cannot set feedback");
     }
-    this._app.feedback = feedback;
   }
 
   get feedback() {
@@ -58,10 +60,11 @@ class OpcBase {
   }
 
   set api(api: Client) {
-    if (this._app.api) {
-      throw new Error("Cannot set feedback");
+    if (!this._app.api) {
+      this._app.api = api;
+    } else {
+      this._app.config?.isDebugMode && console.warn("Cannot set api client");
     }
-    this._app.api = api;
   }
 
   get api() {

--- a/packages/opc-base/src/opc-base/types.ts
+++ b/packages/opc-base/src/opc-base/types.ts
@@ -2,7 +2,7 @@ import { CreateFeedbackVariable, FeedbackReturn } from "../gql/types";
 import { OpKeycloakAuthProvider } from "../keycloakAuthProvider/keycloakAuthProvider";
 import { ToastOptions } from "../components/opc-toast/types";
 import { Notification } from "../opc-provider/types";
-import { Client, RequestPolicy } from '@urql/core';
+import { Client, RequestPolicy } from "@urql/core";
 
 export type KeycloakConfig = {
   keycloakUrl: string;
@@ -14,6 +14,7 @@ export type Config = {
   apiBasePath: string;
   subscriptionsPath: string;
   cachePolicy?: RequestPolicy;
+  isDebugMode?: boolean;
 } & KeycloakConfig;
 
 export type Feedback = {


### PR DESCRIPTION
# Fixes

# Explain the feature/fix

opc-base provides a singleton api that contains api for feedback, toast etc.

To avoid mutating these instances after set by opc-provider, opc-base was throwing error. This had two negative effect. 

1. React hot reloading sometimes reloads opc-provider and issue is opc-base config is singleton, so it wont be reloaded together and it contains the configuration already firing this error.
2. Doc spa reloads the provider completely on page traversal causing this error

Changing from error to warning and added debug mode to avoid apps from showing it in console if not needed.

## Does this PR introduce a breaking change

No

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshots below this line -->

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
