### PR TITLE
fix(1691): lighthouse - fixed leaderboard cache policy issue

### DIFF
--- a/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.ts
+++ b/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.ts
@@ -1,6 +1,8 @@
 import { Component, Inject, LOCALE_ID, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { DashboardService } from 'app/dashboard/dashboard.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-analysis',
@@ -47,6 +49,8 @@ export class AnalysisComponent implements OnInit {
     domain: ['#0066CC', '#EE0000', '#3E8635', '#F0AB00', '#151515'],
   } as any;
 
+  destroySub: Subject<boolean> = new Subject<boolean>();
+
   constructor(
     private router: ActivatedRoute,
     private dashboardService: DashboardService,
@@ -54,17 +58,20 @@ export class AnalysisComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.router.queryParams.subscribe((params) => {
-      this.title = params.name as string;
-    });
+    this.router.queryParams
+      .pipe(takeUntil(this.destroySub))
+      .subscribe((params) => {
+        this.title = params.name as string;
+      });
     // setting debounce subscription
 
-    this.router.params.subscribe((params) => {
+    this.router.params.pipe(takeUntil(this.destroySub)).subscribe((params) => {
       this.projectId = params.id;
       try {
         this.dashboardService
           .listLHProjectBranches(this.projectId)
-          .valueChanges.subscribe(({ data }) => {
+          .valueChanges.pipe(takeUntil(this.destroySub))
+          .subscribe(({ data }) => {
             const { rows } = data.listLHProjectBranches;
             this.branches = this.handlePriorityOrderBranch(rows);
             this.isPageLoading = false;
@@ -82,6 +89,10 @@ export class AnalysisComponent implements OnInit {
     });
   }
 
+  ngOnDestroy() {
+    this.destroySub.next(true);
+    this.destroySub.unsubscribe();
+  }
   /**
    * A function to reorder the fetched branch list
    * with master or main at front
@@ -107,7 +118,8 @@ export class AnalysisComponent implements OnInit {
         this.isBranchLoading = true;
         this.dashboardService
           .ListLHProjectScores(this.projectId, branch)
-          .valueChanges.subscribe(({ data, loading }) => {
+          .valueChanges.pipe(takeUntil(this.destroySub))
+          .subscribe(({ data, loading }) => {
             this.isBranchLoading = false;
             this.buildScores = {
               ...this.buildScores,

--- a/packages/lighthouse-spa/src/app/dashboard/pages/home/home.component.ts
+++ b/packages/lighthouse-spa/src/app/dashboard/pages/home/home.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 
 import { DashboardService } from 'app/dashboard/dashboard.service';
 import { environment } from 'environments/environment';
-import { Subject } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
 @Component({
@@ -21,6 +21,7 @@ export class HomeComponent implements OnInit {
   searchProject = '';
   searchControl = new Subject<string>();
   debouncedSearchProject = '';
+  dashboardServiceSub: Subscription;
 
   isEmpty = false;
   sites = '';
@@ -56,6 +57,7 @@ export class HomeComponent implements OnInit {
         "Each test comes with helpful steps to improve your site's results.",
     },
   ];
+
   constructor(
     private dashboardService: DashboardService,
     private router: Router
@@ -69,7 +71,7 @@ export class HomeComponent implements OnInit {
           this.debouncedSearchProject = searchTerm;
         },
       });
-    this.dashboardService
+    this.dashboardServiceSub = this.dashboardService
       .listLHProjects()
       .valueChanges.subscribe(({ data, loading }) => {
         this.isProjectListLoading = loading;
@@ -80,6 +82,7 @@ export class HomeComponent implements OnInit {
 
   ngOnDestroy(): void {
     this.searchControl.unsubscribe();
+    this.dashboardServiceSub.unsubscribe();
   }
 
   validateUrl(url: string): void {

--- a/packages/lighthouse-spa/src/app/leaderboard/leaderboard.service.ts
+++ b/packages/lighthouse-spa/src/app/leaderboard/leaderboard.service.ts
@@ -28,6 +28,7 @@ export class LeaderboardService extends GraphQLModule {
         limit,
         offset,
       },
+      fetchPolicy:'network-only'
     });
   }
 }

--- a/packages/lighthouse-spa/src/app/leaderboard/pages/leaderboard/leaderboard.component.ts
+++ b/packages/lighthouse-spa/src/app/leaderboard/pages/leaderboard/leaderboard.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { LeaderboardCategory } from 'app/leaderboard/enum';
 import { LeaderboardService } from 'app/leaderboard/leaderboard.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-leaderboard',
@@ -18,6 +19,7 @@ export class LeaderboardComponent implements OnInit {
   leaderboardSortDir: Sort[] = ['DESC', 'ASC'];
 
   lighthouseLeaderboard: LHLeaderboard[] = [];
+  listLeaderBoardSubscription: Subscription;
 
   leaderbooardSelectedCategory = LeaderboardCategory.PWA;
   leaderboardSelectedSortOrder: Sort = 'DESC';
@@ -38,11 +40,15 @@ export class LeaderboardComponent implements OnInit {
     this.fetchLHLeaderboard();
   }
 
+  ngOnDestroy (): void {
+    this.listLeaderBoardSubscription.unsubscribe()
+  }
+
   fetchLHLeaderboard(): void {
     this.isPageLoading = true;
 
     try {
-      this.leaderboardService
+      this.listLeaderBoardSubscription =  this.leaderboardService
         .listLHLeaderboard(
           this.leaderbooardSelectedCategory,
           this.leaderboardSelectedSortOrder,
@@ -53,7 +59,7 @@ export class LeaderboardComponent implements OnInit {
           this.isPageLoading = loading;
           this.totalCount = listLHLeaderboard.count;
           this.lighthouseLeaderboard = listLHLeaderboard.rows;
-        });
+        } );
     } catch (error) {
       window.OpNotification.danger({
         subject: 'Error on loading leaderboard',


### PR DESCRIPTION
# Closes

1691

# Explain the feature/fix

1. Changed leaderboard graphql policy to `network-policy` due to an apollo graphql collision issue with other one
2. added unsubcription to all rxjs subscription made in all pages

## Does this PR introduce a breaking change

No

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

## Fixed Leader board

https://user-images.githubusercontent.com/31166322/143402718-7ac53b01-0d51-4a31-b4ca-61a507179f2b.mov

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
