### PR TITLE
feat(1307): dev-console - implemented feedback list page

### DIFF
--- a/packages/developer-console-spa/package-lock.json
+++ b/packages/developer-console-spa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-console-spa",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/developer-console-spa/package.json
+++ b/packages/developer-console-spa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-console-spa",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "homepage": "/console",
   "description": "The place where developers can get started with using One Platform for SPA deployments and integrating with One Platform Microservices.",
   "author": {
@@ -18,6 +18,7 @@
     "@hookform/resolvers": "2.8.0",
     "@patternfly/patternfly": "4.102.2",
     "@patternfly/react-core": "4.152.4",
+    "@patternfly/react-icons": "^4.32.1",
     "@patternfly/react-table": "^4.30.3",
     "@sentry/react": "^6.15.0",
     "@testing-library/jest-dom": "5.11.9",

--- a/packages/developer-console-spa/src/@types/Feedback/types.d.ts
+++ b/packages/developer-console-spa/src/@types/Feedback/types.d.ts
@@ -9,6 +9,45 @@ declare type FeedbackConfig = {
   feedbackEmail: string;
 };
 
+declare enum FeedbackCategory {
+  BUG = "BUG",
+  FEEDBACK = "FEEDBACK",
+}
+
+declare enum FeedbackStatus {
+  CLOSED = "CLOSED",
+  OPEN = "OPEN",
+}
+
+type FeedbackUserProfile = {
+  cn: String;
+  name: string;
+  uid: string;
+  rhatUUID: string;
+  email: string;
+  url: string;
+};
+
+declare type FeedbackType = {
+  id: string;
+  summary: string;
+  description: string;
+  experience: string;
+  error: string;
+  config: string;
+  state: string;
+  source: string;
+  ticketUrl: string;
+  category: FeedbackCategory;
+  module: string;
+  stackInfo: StackType;
+  assignee: FeedbackUserProfile;
+  createdOn: string;
+  createdBy: string | FeedbackUserProfile;
+  updatedOn: string;
+  updatedBy: string | FeedbackUserProfile;
+};
+
 type FeedbackSourceHeader = {
   key: string;
   value: string;

--- a/packages/developer-console-spa/src/App.tsx
+++ b/packages/developer-console-spa/src/App.tsx
@@ -8,7 +8,8 @@ import AppOverview from './components/AppOverview';
 import NotFound from './components/NotFound';
 import AddAppForm from './components/AddAppForm';
 import UnderDevelopment from './components/UnderDevelopment';
-import ConfigureFeedback from './components/ConfigureFeedback';
+import FeedbackList from "./components/feedback/FeedbackList";
+import ConfigureFeedback from "./components/feedback/ConfigureFeedback";
 import ConfigureLighthouse from './components/ConfigureLighthouse';
 import ConfigureSSI from './components/ConfigureSSI';
 import ConfigureDatabase from './components/ConfigureDatabase';
@@ -28,7 +29,8 @@ function App() {
               <Route path="/:appId/analytics" component={ UnderDevelopment } exact />
               <Route path="/:appId/ssi" component={ ConfigureSSI } exact />
               <Route path="/:appId/database" component={ ConfigureDatabase } exact />
-              <Route path="/:appId/feedback" component={ ConfigureFeedback } exact />
+              <Route path="/:appId/feedback" component={ FeedbackList } exact />
+              <Route path="/:appId/feedback/edit" component={ ConfigureFeedback } exact />
               <Route path="/:appId/lighthouse" component={ ConfigureLighthouse } exact />
               <Route path="/:appId/search" component={ UnderDevelopment } exact />
               <Route path="/:appId/couchdb" component={ ConfigureCouchDB } />

--- a/packages/developer-console-spa/src/components/feedback/ConfigureFeedback.tsx
+++ b/packages/developer-console-spa/src/components/feedback/ConfigureFeedback.tsx
@@ -26,11 +26,11 @@ import * as yup from "yup";
 import {
   createFeedbackConfigService,
   updateFeedbackConfigService,
-} from "../services/feedbackConfig";
-import Header from "./Header";
-import Loader from "./Loader";
-import { AppContext } from "../context/AppContext";
-import useFeedbackConfig from "../hooks/useFeedbackConfig";
+} from "services/feedbackConfig";
+import Header from "../Header";
+import Loader from "../Loader";
+import { AppContext } from "context/AppContext";
+import useFeedbackConfig from "hooks/useFeedbackConfig";
 import { requiredMsg } from "utils/formErrorMsg";
 
 const feedbackTargets = [
@@ -89,7 +89,11 @@ const formSchema = yup
   .required();
 
 function ConfigureFeedback() {
-  const { appId, loading: appLoading } = useContext(AppContext);
+  /**
+   * appId: it is the unique slug generated for an app used in url
+   * app.id: its db id of an app in app service. Used for reference in other services
+   */
+  const { appId, loading: appLoading, app } = useContext(AppContext);
   const {
     feedbackConfig,
     setFeedbackConfig,
@@ -114,7 +118,7 @@ function ConfigureFeedback() {
   const isUpdate = Boolean(feedbackConfig.id);
 
   const saveFeedbackConfig = async (formData: FormData) => {
-    const data = { ...formData, appId };
+    const data = { ...formData, appId: app.id };
     try {
       if (isUpdate) {
         await updateFeedbackConfigService(feedbackConfig.id, data);

--- a/packages/developer-console-spa/src/components/feedback/FeedbackList.tsx
+++ b/packages/developer-console-spa/src/components/feedback/FeedbackList.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useContext, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Bullseye,
+  Button,
+  Card,
+  CardBody,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Label,
+  Pagination,
+  SearchInput,
+  Select,
+  SelectOption,
+  Spinner,
+  Split,
+  SplitItem,
+  Stack,
+  StackItem,
+  Title,
+} from "@patternfly/react-core";
+import {
+  TableComposable,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@patternfly/react-table";
+import SearchIcon from "@patternfly/react-icons/dist/esm/icons/search-icon";
+import { ExternalLinkAltIcon } from "@patternfly/react-icons";
+import { useToggle } from "hooks/useToggle";
+import { usePagination } from "hooks/usePagination";
+import { useDebounce } from "hooks/useDebounce";
+import { AppContext } from "context/AppContext";
+import { getAppFeedbacksService } from "services/feedback";
+
+const FEEDBACK_TABLE_TITLES = ["Created by", "Summary", "Type", "Experience"];
+
+type FeedbackState = {
+  count: number;
+  data: Partial<FeedbackType>[];
+  isLoading?: boolean;
+};
+
+const SORT_SELECT_OPTIONS = [
+  {
+    value: 'CREATED_ON',
+    toString: () => 'Sort by: newest'
+  },
+   {
+    value: 'UPDATED_ON',
+    toString: () => 'Sort by: activity'
+  },
+]
+
+export const FeedbackList = () => {
+  const [isSortOpen, setIsSortOpen] = useToggle();
+  const { loading: appLoading, app } = useContext(AppContext);
+  const { pagination, onPerPageSelect, onSetPage } = usePagination();
+  const [search, setSearch] = useState("");
+  const [sortBy, setSortBy] = useState(SORT_SELECT_OPTIONS[0]);
+
+  const debouncedSearchTerm = useDebounce(
+    search,
+    500,
+    useCallback(() => {
+      onSetPage(1);
+    }, [onSetPage])
+  );
+
+  const [feedbacks, setFeedbacks] = useState<FeedbackState>({
+    count: 0,
+    isLoading: true,
+    data: [],
+  });
+
+  useEffect(() => {
+    if (!appLoading) {
+      setFeedbacks((state) => ({ ...state, isLoading: true }));
+      getAppFeedbacksService(app.id, {
+        limit: pagination.perPage,
+        offset: (pagination.page - 1) * pagination.perPage,
+        search: debouncedSearchTerm,
+        sortBy:sortBy.value,
+      })
+        .then((data) => {
+          setFeedbacks((state) => ({ ...state, ...data }));
+        })
+        .catch((err) => {
+          window.OpNotification({
+            subject: `Failed to fetch feedbacks`,
+            body: err?.message,
+          });
+        })
+        .finally(() =>
+          setFeedbacks((state) => ({ ...state, isLoading: false }))
+        );
+    }
+  }, [
+    appLoading,
+    app.id,
+    pagination.perPage,
+    pagination.page,
+    debouncedSearchTerm,
+    sortBy,
+  ]);
+
+  const handleFeedbackSearchChange = (value: string) => {
+    setSearch(value);
+  };
+
+  const handleFeedbackSortChange = (
+    _evt: React.MouseEvent | React.ChangeEvent,
+    selection: any
+  ) => {
+    setSortBy(selection);
+    setIsSortOpen.off();
+  };
+
+  return (
+    <Card>
+      <CardBody>
+        <Stack hasGutter>
+          <StackItem>
+            <Title headingLevel="h3">User Feedback</Title>
+          </StackItem>
+          <StackItem>
+            <Split hasGutter>
+              <SplitItem isFilled>
+                <SearchInput
+                  placeholder="Search by summary"
+                  style={{ maxWidth: "320px" }}
+                  onChange={handleFeedbackSearchChange}
+                />
+              </SplitItem>
+              <SplitItem>
+                <Link to="feedback/edit">
+                  <Button variant="primary">Edit Feedback Config</Button>
+                </Link>
+              </SplitItem>
+              <SplitItem>
+                <Select
+                  isOpen={isSortOpen}
+                  onToggle={setIsSortOpen.toggle}
+                  onSelect={ handleFeedbackSortChange }
+                  selections={sortBy}
+                >
+                  {SORT_SELECT_OPTIONS.map((value, index) => (
+                    <SelectOption
+                      key={`feedback-sort-${index}`}
+                      value={value}
+                    />
+                  ))}
+                </Select>
+              </SplitItem>
+            </Split>
+          </StackItem>
+          <StackItem>
+            <TableComposable aria-label="Feedback" variant="compact">
+              <Thead>
+                <Tr>
+                  {FEEDBACK_TABLE_TITLES.map((title, columnIndex) => (
+                    <Th key={`$feedback-head-${columnIndex}`}>{title}</Th>
+                  ))}
+                </Tr>
+              </Thead>
+              <Tbody>
+                {feedbacks.isLoading ? (
+                  <Tr>
+                    <Td colSpan={8}>
+                      <Bullseye>
+                        <EmptyState>
+                          <EmptyStateIcon
+                            variant="container"
+                            component={Spinner}
+                          />
+                          <Title size="lg" headingLevel="h4">
+                            Loading
+                          </Title>
+                        </EmptyState>
+                      </Bullseye>
+                    </Td>
+                  </Tr>
+                ) : (
+                  <>
+                    {feedbacks.data.length === 0 && (
+                      <Tr>
+                        <Td colSpan={8}>
+                          <Bullseye>
+                            <EmptyState variant={EmptyStateVariant.small}>
+                              <EmptyStateIcon icon={SearchIcon} />
+                              <Title headingLevel="h2" size="lg">
+                                No results found
+                              </Title>
+                            </EmptyState>
+                          </Bullseye>
+                        </Td>
+                      </Tr>
+                    )}
+                    {feedbacks.data.map(
+                      (
+                        { summary, createdBy, category, experience },
+                        rowIndex
+                      ) => {
+                        const isEvenRow = rowIndex % 2;
+                        return (
+                          <Tr
+                            key={`feedback-rows-${rowIndex}`}
+                            style={
+                              isEvenRow
+                                ? { backgroundColor: "#FAFAFA" }
+                                : undefined
+                            }
+                          >
+                            <Td>{(createdBy as FeedbackUserProfile)?.cn}</Td>
+                            <Td>{summary}</Td>
+                            <Td>
+                              <Label color="blue">{category}</Label>
+                            </Td>
+                            <Td>
+                              <Label color="blue">{experience}</Label>
+                            </Td>
+                            <Td style={{ textAlign: "right" }}>
+                              <Button
+                                variant="link"
+                                icon={
+                                  <ExternalLinkAltIcon
+                                    width="12px"
+                                    height="12px"
+                                  />
+                                }
+                                iconPosition="right"
+                              >
+                                View
+                              </Button>
+                            </Td>
+                          </Tr>
+                        );
+                      }
+                    )}
+                  </>
+                )}
+              </Tbody>
+            </TableComposable>
+            <Pagination
+              itemCount={feedbacks?.count}
+              isCompact
+              perPage={pagination.perPage}
+              page={pagination.page}
+              onSetPage={(_evt, newPage) => onSetPage(newPage)}
+              widgetId="feedback-pagination"
+              onPerPageSelect={(_evt, perPage) => onPerPageSelect(perPage)}
+            />
+          </StackItem>
+        </Stack>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default FeedbackList;

--- a/packages/developer-console-spa/src/hooks/useDebounce.tsx
+++ b/packages/developer-console-spa/src/hooks/useDebounce.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+// Ref: https://usehooks.com/useDebounce/
+export const useDebounce = <T extends unknown>(value: T, delay = 500, cb?:() => void): T => {
+  // State and setters for debounced value
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(
+    () => {
+      // Update debounced value after delay
+      const handler = setTimeout(() => {
+        setDebouncedValue(value);
+        cb && cb();
+      }, delay);
+      // Cancel the timeout if value changes (also on delay change or unmount)
+      // This is how we prevent debounced value from updating if value is changed ...
+      // .. within the delay period. Timeout gets cleared and restarted.
+      return () => {
+        clearTimeout(handler);
+      };
+    },
+    [value, delay, cb] // Only re-call effect if value or delay changes
+  );
+
+  return debouncedValue;
+};

--- a/packages/developer-console-spa/src/hooks/usePagination.tsx
+++ b/packages/developer-console-spa/src/hooks/usePagination.tsx
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react';
+
+type Props = {
+  // initial state
+  page?: number;
+  perPage?: number;
+};
+
+type UsePaginationReturn = {
+  pagination: Required<Props>;
+  onSetPage: (page: number) => void;
+  onPerPageSelect: (perPage: number) => void;
+  onResetPagination: () => void;
+};
+
+export const usePagination = ({ page = 1, perPage = 20 }: Props = {}): UsePaginationReturn => {
+  const [pagination, setPagination] = useState({ page, perPage });
+
+  const onSetPage = useCallback((pageNumber: number): void => {
+    setPagination((state) => ({ ...state, page: pageNumber }));
+  }, []);
+
+  const onPerPageSelect = useCallback((perPageSelected: number) => {
+    setPagination((state) => ({ ...state, perPage: perPageSelected }));
+  }, []);
+
+  const onResetPagination = useCallback(() => {
+    setPagination({ page, perPage });
+  }, [page, perPage]);
+
+  return {
+    pagination,
+    onSetPage,
+    onPerPageSelect,
+    onResetPagination,
+  };
+};

--- a/packages/developer-console-spa/src/hooks/useToggle.ts
+++ b/packages/developer-console-spa/src/hooks/useToggle.ts
@@ -1,0 +1,30 @@
+import { useCallback, useState } from 'react';
+
+type VoidFn = () => void;
+
+type useToggleReturn = [
+  boolean,
+  {
+    on: VoidFn;
+    off: VoidFn;
+    toggle: VoidFn;
+  }
+];
+
+export const useToggle = (initialState = false): useToggleReturn => {
+  const [value, setValue] = useState(initialState);
+
+  const on = useCallback(() => {
+    setValue(true);
+  }, []);
+
+  const off = useCallback(() => {
+    setValue(false);
+  }, []);
+
+  const toggle = useCallback((isOpen?: boolean) => {
+    setValue((prev) => (typeof isOpen === 'boolean' ? isOpen : !prev));
+  }, []);
+
+  return [value, { on, off, toggle }];
+};

--- a/packages/developer-console-spa/src/services/feedback.ts
+++ b/packages/developer-console-spa/src/services/feedback.ts
@@ -1,0 +1,36 @@
+import { getAppFeedbacks } from "../utils/gql-queries";
+import gqlClient from "../utils/gqlClient";
+
+type Filters = {
+  limit?: number;
+  offset?: number;
+  search?: string;
+  sortBy?: string;
+};
+
+export const getAppFeedbacksService = async (
+  appId: string,
+  { limit = 20, offset = 0, search = "", sortBy }: Filters = {}
+): Promise<{ count: number; data: Partial<FeedbackType>[] }> => {
+  return gqlClient({
+    query: getAppFeedbacks,
+    variables: {
+      appId: [appId],
+      limit,
+      offset,
+      search,
+      sortBy,
+    },
+  })
+    .then((res) => {
+      if (res?.errors && !res?.data?.listFeedbacks) {
+        const errMessage = res.errors.map((err: any) => err.message).join(", ");
+        throw new Error(errMessage);
+      }
+      return res.data.listFeedbacks;
+    })
+    .catch((err) => {
+      console.error(err);
+      throw err;
+    });
+};

--- a/packages/developer-console-spa/src/utils/gql-queries/get-app-feedbacks.ts
+++ b/packages/developer-console-spa/src/utils/gql-queries/get-app-feedbacks.ts
@@ -1,0 +1,28 @@
+export const getAppFeedbacks = /* GraphQL */ `
+  query listFeedbacks(
+    $appId: [String]
+    $search: String
+    $limit: Int
+    $offset: Int
+    $sortBy: FeedbackSortType
+  ) {
+    listFeedbacks(
+      appId: $appId
+      search: $search
+      limit: $limit
+      offset: $offset
+      sortBy: $sortBy
+    ) {
+      count
+      data {
+        id
+        summary
+        category
+        experience
+        createdBy {
+          cn
+        }
+      }
+    }
+  }
+`;

--- a/packages/developer-console-spa/src/utils/gql-queries/index.ts
+++ b/packages/developer-console-spa/src/utils/gql-queries/index.ts
@@ -19,3 +19,4 @@ export * from './get-user-by';
 export * from './manage-app-database';
 export * from './create-feedback-config';
 export * from './update-feedback-config';
+export * from './get-app-feedbacks';


### PR DESCRIPTION
# Closes

1. 1307

# Explain the feature/fix

1. Implemented feedback list page in dev console
2. Fixed a typo made in feedback configuration in console. appId -> app.id

## Does this PR introduce a breaking change

Yes

1. Old feedback configure page is now feedback listing page

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

## Feedback Listing

![Screenshot 2022-01-21 at 3 52 20 PM](https://user-images.githubusercontent.com/31166322/150515616-676e595d-ea18-49db-b08d-adb7bd929f0f.png)

## Feedback Loading

![Screenshot 2022-01-21 at 3 52 30 PM](https://user-images.githubusercontent.com/31166322/150515646-7f8cc199-c9a3-4ce1-b784-b5ffadac3afd.png)

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [ ] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
