### PR TITLE
feat(1835): lighthouse-service : implemented leaderboard query changes

### DIFF
--- a/packages/lighthouse-service/package-lock.json
+++ b/packages/lighthouse-service/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/lighthouse-service/package.json
+++ b/packages/lighthouse-service/package.json
@@ -5,7 +5,7 @@
     "className": "Lighthouse",
     "serviceName": "lighthouse"
   },
-  "version": "0.0.3",
+  "version": "0.0.4",
   "keywords": [
     "lighthouse",
     "one-platform",

--- a/packages/lighthouse-service/src/audit-manager/typedef.graphql
+++ b/packages/lighthouse-service/src/audit-manager/typedef.graphql
@@ -11,6 +11,7 @@ enum LHLeaderBoardCategory {
   BEST_PRACTICES
   ACCESSIBILITY
   PERFORMANCE
+  OVERALL
 }
 
 input LighthouseInput {
@@ -75,7 +76,7 @@ type LighthouseLeaderBoardBuildType {
 }
 
 type LighthouseLeaderBoardType {
-  score: Int
+  score: LighthouseScoreType
   rank: Int
   build: LighthouseLeaderBoardBuildType
   project: LighthouseProjectType
@@ -137,7 +138,17 @@ type Query {
     limit: Int
     offset: Int
     sort: Sort
+    search: String
   ): ListLHLeaderBoard
+   """
+  Fetch the leaderboard rank of a build
+  """
+  getLHRankingOfABuild(
+    type: LHLeaderBoardCategory!
+    projectId: String!
+    buildId: String!
+    sort: Sort
+  ): LighthouseLeaderBoardType
 }
 
 type Mutation {

--- a/packages/lighthouse-service/src/e2e/lighthouse.spec.ts
+++ b/packages/lighthouse-service/src/e2e/lighthouse.spec.ts
@@ -35,7 +35,26 @@ const query = `
       count
       rows {
         rank
-        score
+        score {
+            accessibility
+            performance
+            pwa
+            bestPractices
+            seo
+        }
+      }
+    }
+  }
+
+   query GetLHRankingOfABuild($type: LHLeaderBoardCategory!, $projectId: String!, $buildId: String!) {
+    getLHRankingOfABuild(type: $type, projectId: $projectId, buildId: $buildId){
+      rank
+      score {
+          accessibility
+          performance
+          pwa
+          bestPractices
+          seo
       }
     }
   }
@@ -123,6 +142,30 @@ describe('Lighthouse audit manager API Test', () => {
         expect(res.body.data.listLHLeaderboard).toHaveProperty('rows');
         expect(res.body.data.listLHLeaderboard.rows[0]).toHaveProperty('rank');
         expect(res.body.data.listLHLeaderboard.rows[0]).toHaveProperty('score');
+      })
+      .end((err) => {
+        done(err);
+      });
+  });
+
+  it('Pull the leaderboard rank of a build from the lighthouse server', (done) => {
+    request
+      .post('/graphql')
+      .send({
+        query,
+        operationName: 'GetLHRankingOfABuild',
+        variables: {
+          type: 'ACCESSIBILITY',
+          projectId: mock.projectId,
+          buildId: mock.buildID,
+        },
+      })
+      .expect((res) => {
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data).toHaveProperty('getLHRankingOfABuild');
+        expect(res.body.data.getLHRankingOfABuild).toHaveProperty('rank');
+        expect(res.body.data.getLHRankingOfABuild).toHaveProperty('score');
       })
       .end((err) => {
         done(err);

--- a/packages/lighthouse-service/src/lighthouse-db-manager/sequelize.ts
+++ b/packages/lighthouse-service/src/lighthouse-db-manager/sequelize.ts
@@ -3,4 +3,4 @@ import { Sequelize } from 'sequelize';
 const LH_DATABASE_URI = `postgres://${
   process.env.LH_DB_USER}:${process.env.LH_DB_PASSWORD}@${process.env.LH_DB_URL}/${process.env.LH_DB_NAME}`;
 
-export const sequelize = new Sequelize(LH_DATABASE_URI, { logging: false });
+export const sequelize = new Sequelize(LH_DATABASE_URI, { logging: true });

--- a/packages/lighthouse-service/src/lighthouse-db-manager/types.ts
+++ b/packages/lighthouse-service/src/lighthouse-db-manager/types.ts
@@ -71,15 +71,21 @@ export type Sort = {
 };
 
 export type LeadboardStatistic = {
-  score: number;
+  score: number | LighthouseScoreType;
   rank: number;
-  buildId: number;
-  projectId: number;
+  buildId: string;
+  projectId: string;
   project: LighthouseProjectType;
   build: LighthouseBuildType;
 };
 
-export type LeaderBoardOptions = Omit<Pagination, 'search'> &
+export type LeaderBoardOptions = Pagination &
 Optional<Sort, 'sort'> & {
   type?: string;
 };
+
+export type BuildLeaderboardRankOption = {
+  projectId: string;
+  buildId: string;
+  type?: string;
+} & Partial<Sort>;


### PR DESCRIPTION
# Closes

1. 1835

# Explain the feature/fix

1. Updated queries to support the new leaderboard
2. Updated unit testcase

## Does this PR introduce a breaking change

1. Leader board score is now an object that contains all other data.

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshots below this line -->

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?
