### PR TITLE
hotfix(lighthouse-spa): removed asc sort order in dashboard leaderboard and made line chart responsive

### DIFF
--- a/packages/lighthouse-spa/package-lock.json
+++ b/packages/lighthouse-spa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-spa",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/lighthouse-spa/package.json
+++ b/packages/lighthouse-spa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-spa",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "scripts": {
     "ng": "ng",
     "start": "npm run config -- --environment=dev && ng serve",

--- a/packages/lighthouse-spa/src/app/dashboard/dashboard.gql.ts
+++ b/packages/lighthouse-spa/src/app/dashboard/dashboard.gql.ts
@@ -70,6 +70,7 @@ export const ListLHLeaderboard = gql`
         }
         rank
         build {
+          id
           branch
         }
         project {

--- a/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.html
+++ b/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.html
@@ -69,7 +69,7 @@
         <div class="pf-l-flex__item">
           <div class="pf-l-grid pf-m-gutter">
             <!-- pie chart -->
-            <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-2xl pf-c-card score-card">
+            <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-3xl pf-c-card score-card">
               <div class="pf-c-card__body">
                 <div class="pf-u-p-2xl pf-l-flex pf-m-nowrap pf-m-justify-content-center score-loader-container"
                   *ngIf="isBranchLoading">
@@ -96,18 +96,16 @@
             </div>
 
             <!-- line chart -->
-            <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-2xl pf-c-card score-card">
-              <div class="pf-c-card__body">
+            <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-3xl pf-c-card score-card">
+              <div class="pf-c-card__body line-chart-container">
                 <div class="pf-u-p-2xl pf-l-flex pf-m-nowrap pf-m-justify-content-center score-loader-container"
                   *ngIf="isBranchLoading">
                   <app-loader></app-loader>
                 </div>
-                <ngx-charts-line-chart *ngIf="!isBranchLoading" [view]="[800, 350]" [scheme]="timelineColorSchema"
-                  [timeline]="true" [results]="
-                    buildScores[selectedBranch] | timelineScoreFormater
-                  " [legend]="legend" [xAxis]="xAxis" [yAxis]="yAxis" [timeline]="timeline"
-                  [referenceLines]="referenceLines" [showRefLines]="showRefLines" [yScaleMax]="yScaleMax"
-                  [yScaleMin]="yScaleMin" [legendTitle]="legendTitle" [xAxisLabel]="xAxisLabel"
+                <ngx-charts-line-chart *ngIf="!isBranchLoading" [scheme]="timelineColorSchema" [timeline]="true"
+                  [results]="buildScores[selectedBranch] | timelineScoreFormater" [legend]="legend" [xAxis]="xAxis"
+                  [yAxis]="yAxis" [timeline]="timeline" [referenceLines]="referenceLines" [showRefLines]="showRefLines"
+                  [yScaleMax]="yScaleMax" [yScaleMin]="yScaleMin" [legendTitle]="legendTitle" [xAxisLabel]="xAxisLabel"
                   [yAxisLabel]="yAxisLabel" [showXAxisLabel]="showXAxisLabel" [showYAxisLabel]="showYAxisLabel">
                 </ngx-charts-line-chart>
               </div>

--- a/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.scss
+++ b/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.scss
@@ -13,3 +13,15 @@
 .score-loader-container {
   min-width: 720px;
 }
+
+@media screen and (min-width: 2100px) {
+  .pf-l-grid > .pf-m-6-col-on-3xl {
+    --pf-l-grid__item--GridColumnEnd: span 6;
+  }
+}
+
+.line-chart-container {
+  display: flex;
+  overflow: hidden;
+  padding: 2rem 0;
+}

--- a/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.ts
+++ b/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.ts
@@ -230,7 +230,7 @@ export class AnalysisComponent implements OnInit {
   ): [LHLeaderboard[], number] {
     let pos = leaders.length;
     for (let i = 0; i < leaders.length; i++) {
-      if (currentBranchRank.build.branch === leaders[i].build.branch) {
+      if (currentBranchRank.build.id === leaders[i].build.id) {
         return [leaders, i];
       }
 
@@ -248,15 +248,9 @@ export class AnalysisComponent implements OnInit {
     );
   }
 
-  handleSortClick({
-    column: columnName,
-    sortDir: dir,
-  }: {
-    column: string;
-    sortDir: 'DESC' | 'ASC';
-  }) {
+  handleSortClick({ column: columnName }) {
     this.columns = this.columns.map(({ sortDir, ...column }) =>
-      column.title === columnName ? { ...column, sortDir: dir } : column
+      column.title === columnName ? { ...column, sortDir: 'DESC' } : column
     );
     this.fetchLHLeaderboard();
   }

--- a/packages/lighthouse-spa/src/app/utils/leaderboardTable.ts
+++ b/packages/lighthouse-spa/src/app/utils/leaderboardTable.ts
@@ -40,14 +40,6 @@ export const getLeaderboardCells = ({
       chipColor: isSelected ? 'blue' : 'gray',
     },
     {
-      title: score.pwa,
-      cellClassName: getScoreColor(score.pwa),
-    },
-    {
-      title: score.seo,
-      cellClassName: getScoreColor(score.seo),
-    },
-    {
       title: score.accessibility,
       cellClassName: getScoreColor(score.accessibility),
     },
@@ -58,6 +50,14 @@ export const getLeaderboardCells = ({
     {
       title: score.performance,
       cellClassName: getScoreColor(score.performance),
+    },
+    {
+      title: score.pwa,
+      cellClassName: getScoreColor(score.pwa),
+    },
+    {
+      title: score.seo,
+      cellClassName: getScoreColor(score.seo),
     },
     {
       title: total,
@@ -74,16 +74,6 @@ export const LEADERBOARD_COLUMNS: (Column & { key?: LeaderboardCategory })[] = [
     title: 'Project',
   },
   {
-    title: 'PWA',
-    isSortable: true,
-    key: LeaderboardCategory.PWA,
-  },
-  {
-    title: 'SEO',
-    isSortable: true,
-    key: LeaderboardCategory.SEO,
-  },
-  {
     title: 'Accessibility',
     isSortable: true,
     key: LeaderboardCategory.ACCESSIBILITY,
@@ -97,6 +87,16 @@ export const LEADERBOARD_COLUMNS: (Column & { key?: LeaderboardCategory })[] = [
     title: 'Performance',
     isSortable: true,
     key: LeaderboardCategory.PERFORMANCE,
+  },
+  {
+    title: 'PWA',
+    isSortable: true,
+    key: LeaderboardCategory.PWA,
+  },
+  {
+    title: 'SEO',
+    isSortable: true,
+    key: LeaderboardCategory.SEO,
   },
   {
     title: 'Total',


### PR DESCRIPTION
# Resolves

### <!-- Any of the keywords: Closes/Fixes/Resolves followed by #issue_id (should be separated by a space only) -->

# Explain the feature/fix

1. Removed ASC sort order in leaderboard of dashboard page
2. Changed grid layout stacking in small screen
3. Made line chart responsive

## Does this PR introduce a breaking change

No

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

## Dashboard in large screen

![Screenshot 2022-02-11 at 12 08 02 PM](https://user-images.githubusercontent.com/31166322/153547858-0e1da66e-887c-471d-9171-66642f9d2ec2.png)

## Dashboard in smaller screen

![Screenshot 2022-02-11 at 12 08 22 PM](https://user-images.githubusercontent.com/31166322/153547889-eb74c74d-6ea4-44cc-ad29-7ac94ba22d3c.png)


</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?
