### PR TITLE
feat(1873): lighthouse-service: leaderboard updated to branch based and improved accuracy

### DIFF
--- a/packages/lighthouse-service/package-lock.json
+++ b/packages/lighthouse-service/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/lighthouse-service/package.json
+++ b/packages/lighthouse-service/package.json
@@ -5,7 +5,7 @@
     "className": "Lighthouse",
     "serviceName": "lighthouse"
   },
-  "version": "0.0.4",
+  "version": "0.0.5",
   "keywords": [
     "lighthouse",
     "one-platform",

--- a/packages/lighthouse-service/src/audit-manager/resolver.ts
+++ b/packages/lighthouse-service/src/audit-manager/resolver.ts
@@ -54,8 +54,8 @@ export const LighthouseAuditResolver = {
     async listLHLeaderboard(root: any, args: any) {
       return lhDbManager.getLeaderBoard(args);
     },
-    async getLHRankingOfABuild(root: any, args: any) {
-      return lhDbManager.getLHRankingOfABuild(args);
+    async getLHRankingOfAProjectBranch(root: any, args: any) {
+      return lhDbManager.getLHRankingOfAProjectBranch(args);
     },
   },
   Mutation: {

--- a/packages/lighthouse-service/src/audit-manager/typedef.graphql
+++ b/packages/lighthouse-service/src/audit-manager/typedef.graphql
@@ -78,7 +78,7 @@ type LighthouseLeaderBoardBuildType {
 type LighthouseLeaderBoardType {
   score: LighthouseScoreType
   rank: Int
-  build: LighthouseLeaderBoardBuildType
+  branch: String
   project: LighthouseProjectType
 }
 
@@ -141,12 +141,12 @@ type Query {
     search: String
   ): ListLHLeaderBoard
    """
-  Fetch the leaderboard rank of a build
+  Fetch the leaderboard rank of a project branch
   """
-  getLHRankingOfABuild(
+  getLHRankingOfAProjectBranch(
     type: LHLeaderBoardCategory!
     projectId: String!
-    buildId: String!
+    branch: String!
     sort: Sort
   ): LighthouseLeaderBoardType
 }

--- a/packages/lighthouse-service/src/e2e/lighthouse.spec.ts
+++ b/packages/lighthouse-service/src/e2e/lighthouse.spec.ts
@@ -46,8 +46,8 @@ const query = `
     }
   }
 
-   query GetLHRankingOfABuild($type: LHLeaderBoardCategory!, $projectId: String!, $buildId: String!) {
-    getLHRankingOfABuild(type: $type, projectId: $projectId, buildId: $buildId){
+   query GetLHRankingOfAProjectBranch($type: LHLeaderBoardCategory!, $projectId: String!, $branch: String!) {
+    getLHRankingOfAProjectBranch(type: $type, projectId: $projectId, branch: $branch){
       rank
       score {
           accessibility
@@ -153,19 +153,19 @@ describe('Lighthouse audit manager API Test', () => {
       .post('/graphql')
       .send({
         query,
-        operationName: 'GetLHRankingOfABuild',
+        operationName: 'GetLHRankingOfAProjectBranch',
         variables: {
           type: 'ACCESSIBILITY',
           projectId: mock.projectId,
-          buildId: mock.buildID,
+          branch: 'master',
         },
       })
       .expect((res) => {
         expect(res.body).not.toHaveProperty('errors');
         expect(res.body).toHaveProperty('data');
-        expect(res.body.data).toHaveProperty('getLHRankingOfABuild');
-        expect(res.body.data.getLHRankingOfABuild).toHaveProperty('rank');
-        expect(res.body.data.getLHRankingOfABuild).toHaveProperty('score');
+        expect(res.body.data).toHaveProperty('getLHRankingOfAProjectBranch');
+        expect(res.body.data.getLHRankingOfAProjectBranch).toHaveProperty('rank');
+        expect(res.body.data.getLHRankingOfAProjectBranch).toHaveProperty('score');
       })
       .end((err) => {
         done(err);

--- a/packages/lighthouse-service/src/lighthouse-db-manager/types.ts
+++ b/packages/lighthouse-service/src/lighthouse-db-manager/types.ts
@@ -73,7 +73,7 @@ export type Sort = {
 export type LeadboardStatistic = {
   score: number | LighthouseScoreType;
   rank: number;
-  buildId: string;
+  branch: string;
   projectId: string;
   project: LighthouseProjectType;
   build: LighthouseBuildType;
@@ -86,6 +86,6 @@ Optional<Sort, 'sort'> & {
 
 export type BuildLeaderboardRankOption = {
   projectId: string;
-  buildId: string;
+  branch: string;
   type?: string;
 } & Partial<Sort>;


### PR DESCRIPTION
# Closes

1. 1873

# Explain the feature/fix

1. Leaderboard changed from build based stats to branch specific 
2. Updated counting operation
3. Improved accuracy in averaging

## Does this PR introduce a breaking change

Yes.

1. `getLHRankingOfABuild` got removed and `getLHRankingOfAProjectBranch` got added

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshots below this line -->

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?
