### PR TITLE
feat(1865): reverse-proxy - fixed params missing in no-cors redirect

### DIFF
--- a/packages/reverse-proxy-service/package-lock.json
+++ b/packages/reverse-proxy-service/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reverse-proxy-service",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1198,7 +1198,8 @@
     "@testim/chrome-version": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
-      "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw=="
+      "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
+      "optional": true
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -1690,6 +1691,7 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "optional": true,
       "requires": {
         "follow-redirects": "^1.14.0"
       }
@@ -2394,6 +2396,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
       "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "optional": true,
       "requires": {
         "globby": "^11.0.1",
         "graceful-fs": "^4.2.4",
@@ -2852,6 +2855,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "optional": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
@@ -5601,6 +5605,7 @@
           "version": "97.0.0",
           "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-97.0.0.tgz",
           "integrity": "sha512-SZ9MW+/6/Ypz20CNdRKocsmRM2AJ/YwHaWpA1Np2QVPFUbhjhus6vBtqFD+l8M5qrktLWPQSjTwIsDckNfXIRg==",
+          "optional": true,
           "requires": {
             "@testim/chrome-version": "^1.0.7",
             "axios": "^0.21.2",
@@ -6232,7 +6237,8 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "optional": true
     },
     "psl": {
       "version": "1.8.0",
@@ -6817,6 +6823,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
       "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+      "optional": true,
       "requires": {
         "debug": "4.3.1",
         "is2": "^2.0.6"

--- a/packages/reverse-proxy-service/package.json
+++ b/packages/reverse-proxy-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reverse-proxy-service",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A reverse proxy service for One Platform",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/reverse-proxy-service/src/no-cors-proxy/index.ts
+++ b/packages/reverse-proxy-service/src/no-cors-proxy/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import resolver from './resolver';
 
 const router = Router();
-router.use( '*', resolver);
+// /api/no-cors-proxy/< url to be proxied >
+router.use( '/:url(*)', resolver);
 
 export default router;

--- a/packages/reverse-proxy-service/src/no-cors-proxy/resolver.ts
+++ b/packages/reverse-proxy-service/src/no-cors-proxy/resolver.ts
@@ -1,29 +1,28 @@
-import { Request, Response, NextFunction } from "express";
-import { createProxyMiddleware } from "http-proxy-middleware";
+import { Request, Response, NextFunction } from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
 
-const useSecureSSL = process.env.NODE_TLS_REJECT_UNAUTHORIZED !== "0";
+const useSecureSSL = process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0';
 
-const isValidURL = ( url: string ) => new URL( url );
+const isValidURL = (url: string) => new URL(url);
 
 export default function resolver(
   req: Request,
   res: Response,
   next: NextFunction
 ): void {
-  const url = req.query?.url as string;
+  const url = req.params?.url as string;
   try {
-    isValidURL( url )
+    isValidURL(url);
   } catch (error) {
-     res.status(403).json({ error: "Invalid proxy url" });
+    res.status(403).json({ error: 'Invalid proxy url' });
+    return;
   }
 
   const proxy = createProxyMiddleware({
     target: url,
     secure: useSecureSSL,
     changeOrigin: true,
-    pathRewrite: {
-      ["^/api/no-cors-proxy"]: "",
-    },
+    pathRewrite: (path) => path.replace(`/api/no-cors-proxy/${url}`, ''),
   });
   proxy(req, res, next);
 }


### PR DESCRIPTION
# Closes

1. 1865

# Explain the feature/fix

1. Fixed reverse proxy no-cors redirect to allow params and all other url parameters

## Does this PR introduce a breaking change

Yes

1. Reverse proxy no-cors-proxy format got changed

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshots below this line -->

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?
