### PR TITLE
fix(dev-console): prepend appId to sidebar links

### DIFF
--- a/packages/developer-console-spa/src/components/Sidebar.tsx
+++ b/packages/developer-console-spa/src/components/Sidebar.tsx
@@ -63,10 +63,10 @@ function Sidebar () {
 
         <NavList className="app-details--sidebar--main-nav">
           <NavItem isActive={ isNavItemActive( 'overview' ) }>
-            <Link to={ 'overview' }>Overview</Link>
+            <Link to={`/${ appId}/overview`}>Overview</Link>
           </NavItem>
           <NavItem isActive={ isNavItemActive( 'analytics' ) }>
-            <Link to={ 'analytics' }>Analytics</Link>
+            <Link to={`/${ appId}/analytics`}>Analytics</Link>
           </NavItem>
 
           <Title headingLevel="h4" className="app-details--sidebar--title pf-u-color-400 pf-u-px-md">Integrations</Title>
@@ -79,7 +79,7 @@ function Sidebar () {
         </NavList>
         <NavList className="app-details--sidebar--settings pf-u-mt-auto">
           <NavItem isActive={ isNavItemActive('settings') }>
-            <Link to={ 'settings' }>
+            <Link to={`/${ appId}/settings`}>
               App Settings
               <ion-icon class="pf-u-ml-auto pf-u-my-auto" name="settings-outline"></ion-icon>
             </Link>


### PR DESCRIPTION
# Fixes

Incorrect links to overview, analytics and settings in Developer Console Sidebar

# Explain the feature/fix

Prepended `appId` to the static links in sidebar for Overview, Analytics and Settings

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
