### PR TITLE
feat(1882,1912): lighthouse-spa - added lh server url in dashboard and leaderboard pagination

### DIFF
--- a/packages/lighthouse-spa/package-lock.json
+++ b/packages/lighthouse-spa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-spa",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/lighthouse-spa/package.json
+++ b/packages/lighthouse-spa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-spa",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "scripts": {
     "ng": "ng",
     "start": "npm run config -- --environment=dev && ng serve",

--- a/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.html
+++ b/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.html
@@ -55,13 +55,21 @@
           </div>
           <div class="pf-l-flex__item pf-m-grow"></div>
           <div class="pf-l-flex__item pf-u-font-size-sm pf-u-color-300">
-            Last Report generated at:{{ " " }}
-            {{
-              buildScores.hasOwnProperty(selectedBranch)
-                ? (buildScores[selectedBranch][0].updatedAt
-                  | date: "MMM dd, YY")
-                : "..."
-            }}
+            Last report generated at:{{ " " }}
+                {{
+                  buildScores.hasOwnProperty(selectedBranch)
+                    ? (buildScores[selectedBranch][0].updatedAt
+                      | date: "MMM dd, YY")
+                    : "..."
+                }}
+            <a href="{{this.externalLHServerURL}}" target="_blank" rel="noopener noreferrer">
+              <button class="pf-c-button pf-m-link pf-u-p-xs" type="button">
+                <span class="pf-c-button__icon pf-m-end">
+                  <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                </span>
+              </button>
+            </a>
+            <!-- https://lighthouse.one.redhat.com/app/projects/catalog.redhat.com/dashboard?branch=update-autosuggest-options -->
           </div>
         </div>
 

--- a/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.ts
+++ b/packages/lighthouse-spa/src/app/dashboard/pages/analysis/analysis.component.ts
@@ -8,6 +8,7 @@ import {
   LEADERBOARD_COLUMNS,
 } from 'app/utils/leaderboardTable';
 import { Subject } from 'rxjs';
+import { environment } from 'environments/environment';
 import { takeUntil } from 'rxjs/operators';
 
 @Component({
@@ -61,6 +62,8 @@ export class AnalysisComponent implements OnInit {
   isLeaderboardLoading = true;
   rows: Row[] = [];
   columns = LEADERBOARD_COLUMNS;
+
+  externalLHServerURL = '#';
 
   constructor(
     private router: ActivatedRoute,
@@ -127,6 +130,7 @@ export class AnalysisComponent implements OnInit {
     // to avoid error on dynamic query builder
     this.isLeaderboardLoading = true;
     try {
+      this.externalLHServerURL = `${environment.LH_SERVER_URL}/app/projects/${this.title}/dashboard?branch=${branch}`;
       if (!this.buildScores?.[branch]) {
         this.isBranchLoading = true;
         this.dashboardService

--- a/packages/lighthouse-spa/src/app/leaderboard/pages/leaderboard/leaderboard.component.html
+++ b/packages/lighthouse-spa/src/app/leaderboard/pages/leaderboard/leaderboard.component.html
@@ -28,7 +28,9 @@
             <div class="pf-c-options-menu">
                 <div class="pf-c-options-menu__toggle pf-m-text pf-m-plain">
                     <span class="pf-c-options-menu__toggle-text">
-                        <b>{{ pageOffset + 1 }} - {{ pageOffset + pageLimit }}</b>&nbsp;of&nbsp;
+                        <b>{{ pageOffset + 1 }} -
+                            {{ pageOffset + pageLimit > totalCount ? totalCount : pageOffset + pageLimit }}
+                        </b>&nbsp;of&nbsp;
                         <b>{{ totalCount }}</b>
                     </span>
                     <button class="pf-c-options-menu__toggle-button"


### PR DESCRIPTION
# Closes

1. 1882
2. 1912

# Explain the feature/fix

<!-- Provide a clear explanation of the feature/fix implemented -->

## Does this PR introduce a breaking change

No

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

## Leaderboard Pagination 

![Screenshot 2022-03-04 at 4 19 58 PM](https://user-images.githubusercontent.com/31166322/156755328-4c469362-bac3-40e8-a468-61f8b9a84003.png)

## External Link

![Screenshot 2022-03-04 at 4 20 34 PM](https://user-images.githubusercontent.com/31166322/156755362-33d1ef1a-b042-41ff-92b1-97c326c1ed13.png)

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?
