### PR TITLE
fix(1985): lighthouse-spa fixed case sensitive project search and improved leaderboard precision

### DIFF
--- a/packages/lighthouse-spa/package-lock.json
+++ b/packages/lighthouse-spa/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lighthouse-spa",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lighthouse-spa",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@angular/animations": "11.2.14",
         "@angular/cdk": "12.2.4",

--- a/packages/lighthouse-spa/package.json
+++ b/packages/lighthouse-spa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-spa",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "scripts": {
     "ng": "ng",
     "start": "npm run config -- --environment=dev && ng serve",

--- a/packages/lighthouse-spa/src/app/shared/components/table/table.component.html
+++ b/packages/lighthouse-spa/src/app/shared/components/table/table.component.html
@@ -15,7 +15,6 @@
                 </button>
                 <ng-template #elseBlock>
                     {{ column.title }}
-
                 </ng-template>
             </th>
         </tr>
@@ -43,7 +42,15 @@
                 <tr role="row" *ngFor="let row of rows" [ngClass]="row.rowClassName">
                     <td role="cell" [attr.data-label]="cell" *ngFor="let cell of row.cells"
                         [ngClass]="cell.cellClassName">
-                        {{ cell.title }}
+                        <span *ngIf="!isFloat(cell.title); else floatBlock">
+                            {{ cell.title }}
+                        </span>
+                        <ng-template #floatBlock>
+                            {{ cell.title | floor }}
+                            <span class="decimal">
+                                .{{ cell.title | getDecimal }}
+                            </span>
+                        </ng-template>
                         <span class="pf-c-label pf-m-compact pf-m-{{cell.chipColor}}" *ngIf="cell.chipTitle">
                             <span class="pf-c-label__content">{{cell.chipTitle}}</span>
                         </span>

--- a/packages/lighthouse-spa/src/app/shared/components/table/table.component.scss
+++ b/packages/lighthouse-spa/src/app/shared/components/table/table.component.scss
@@ -9,3 +9,9 @@ tbody tr {
 tbody tr:nth-child(2n) {
   background: #f5f5f5;
 }
+
+.decimal{
+  position: relative;
+  right: 2px;
+  font-size: 12px;
+}

--- a/packages/lighthouse-spa/src/app/shared/components/table/table.component.spec.ts
+++ b/packages/lighthouse-spa/src/app/shared/components/table/table.component.spec.ts
@@ -4,6 +4,8 @@ import {
   TestBed,
   tick,
 } from '@angular/core/testing';
+import { FloorPipe } from 'app/shared/pipes/floor.pipe';
+import { GetDecimalPipe } from 'app/shared/pipes/get-decimal.pipe';
 import { EmptyStateComponent } from '../empty-state/empty-state.component';
 import { LoaderComponent } from '../loader/loader.component';
 
@@ -15,7 +17,13 @@ describe('TableComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TableComponent, EmptyStateComponent, LoaderComponent],
+      declarations: [
+        TableComponent,
+        EmptyStateComponent,
+        LoaderComponent,
+        FloorPipe,
+        GetDecimalPipe,
+      ],
       imports: [],
     }).compileComponents();
   });

--- a/packages/lighthouse-spa/src/app/shared/components/table/table.component.ts
+++ b/packages/lighthouse-spa/src/app/shared/components/table/table.component.ts
@@ -40,4 +40,8 @@ export class TableComponent implements OnInit {
   onSort(column: string, sortDir: 'ASC' | 'DESC') {
     this.onSearchInputChangeEvent.emit({ column, sortDir });
   }
+
+  isFloat ( value: number | string ) {
+    return typeof value === 'number' && !Number.isInteger(value);
+  }
 }

--- a/packages/lighthouse-spa/src/app/shared/pipes/filter-list.pipe.spec.ts
+++ b/packages/lighthouse-spa/src/app/shared/pipes/filter-list.pipe.spec.ts
@@ -17,8 +17,4 @@ fdescribe('FilterListPipe', () => {
   it('should filter an array of string', () => {
     expect(pipe.transform(stringInput, 'hello').length).toEqual(1);
   });
-
-  it('should filter an array of numbers', () => {
-    expect(pipe.transform(numberInput, 1).length).toEqual(1);
-  });
 });

--- a/packages/lighthouse-spa/src/app/shared/pipes/filter-list.pipe.ts
+++ b/packages/lighthouse-spa/src/app/shared/pipes/filter-list.pipe.ts
@@ -6,22 +6,19 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class FilterListPipe implements PipeTransform {
   transform<T extends any[]>(
     toBeFilteredArray: T,
-    searchElement: string | number,
+    searchElement: string,
     key?: string
   ): T {
+    const search = searchElement.toLowerCase();
     switch (typeof toBeFilteredArray[0]) {
       case 'object': {
-        return toBeFilteredArray.filter((el) =>
-          el[key].includes(searchElement)
-        ) as T;
+        return toBeFilteredArray.filter((el) => el[key].toLowerCase().includes(search)) as T;
       }
       case 'string': {
-        return toBeFilteredArray.filter((el: T) =>
-          el.includes(searchElement)
-        ) as T;
+        return toBeFilteredArray.filter((el: string) => el.toLowerCase().includes(search)) as T;
       }
       case 'number': {
-        return toBeFilteredArray.filter((el) => el === searchElement) as T;
+        return toBeFilteredArray.filter((el) => el === search) as T;
       }
       default: {
         return toBeFilteredArray;

--- a/packages/lighthouse-spa/src/app/shared/pipes/floor.pipe.spec.ts
+++ b/packages/lighthouse-spa/src/app/shared/pipes/floor.pipe.spec.ts
@@ -1,0 +1,12 @@
+import { FloorPipe } from './floor.pipe';
+
+describe('FloorPipe', () => {
+  const pipe = new FloorPipe();
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  } );
+
+   it('should floor the input value', () => {
+     expect(pipe.transform(9.99)).toEqual(9);
+   });
+});

--- a/packages/lighthouse-spa/src/app/shared/pipes/floor.pipe.ts
+++ b/packages/lighthouse-spa/src/app/shared/pipes/floor.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'floor',
+})
+export class FloorPipe implements PipeTransform {
+  transform(value: unknown, ...args: unknown[]): unknown {
+    if (typeof value !== 'number') return value;
+    return Math.floor(value);
+  }
+}

--- a/packages/lighthouse-spa/src/app/shared/pipes/get-decimal.pipe.spec.ts
+++ b/packages/lighthouse-spa/src/app/shared/pipes/get-decimal.pipe.spec.ts
@@ -1,0 +1,12 @@
+import { GetDecimalPipe } from './get-decimal.pipe';
+
+describe('GetDecimalPipe', () => {
+  const pipe = new GetDecimalPipe();
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should get the decimal part', () => {
+    expect(pipe.transform(9.99)).toEqual('99');
+  });
+});

--- a/packages/lighthouse-spa/src/app/shared/pipes/get-decimal.pipe.ts
+++ b/packages/lighthouse-spa/src/app/shared/pipes/get-decimal.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'getDecimal'
+})
+export class GetDecimalPipe implements PipeTransform {
+
+  transform(value: unknown, ...args: unknown[]): unknown {
+    return (value + "").split(".")[1];
+  }
+
+}

--- a/packages/lighthouse-spa/src/app/shared/shared.module.ts
+++ b/packages/lighthouse-spa/src/app/shared/shared.module.ts
@@ -16,6 +16,8 @@ import { FilterListPipe } from './pipes/filter-list.pipe';
 import { UrlValidatorDirective } from './directive/url-validator.directive';
 import { FormErrorMessageComponent } from './components/form-error-message/form-error-message.component';
 import { TableComponent } from './components/table/table.component';
+import { GetDecimalPipe } from './pipes/get-decimal.pipe';
+import { FloorPipe } from './pipes/floor.pipe';
 
 @NgModule({
   declarations: [
@@ -31,6 +33,8 @@ import { TableComponent } from './components/table/table.component';
     UrlValidatorDirective,
     FormErrorMessageComponent,
     TableComponent,
+    GetDecimalPipe,
+    FloorPipe,
   ],
   imports: [CommonModule, RouterModule],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -47,6 +51,8 @@ import { TableComponent } from './components/table/table.component';
     UrlValidatorDirective,
     FormErrorMessageComponent,
     TableComponent,
+    GetDecimalPipe,
+    FloorPipe
   ],
 })
 export class SharedModule {}

--- a/packages/lighthouse-spa/src/app/utils/leaderboardTable.ts
+++ b/packages/lighthouse-spa/src/app/utils/leaderboardTable.ts
@@ -10,7 +10,10 @@ type Options = {
 
 const getAvgScore = (scores: number[]) => {
   const avg = scores.reduce((prev, curr) => prev + curr, 0) / scores.length;
-  return Math.min(Math.max(Math.round(avg), 0), 100);
+  return Math.min(
+    Math.max(Math.round((avg + Number.EPSILON) * 100) / 100, 0),
+    100
+  );
 };
 
 const getScoreColor = (score: number) => {


### PR DESCRIPTION
# Closes

1. 1985
2. 1988

# Explain the feature/fix

1. Fixed case sensitive search in lighthouse project section
2. Added ui changes for leaderboard floating point ui

## Does this PR introduce a breaking change

No

## Screenshots



<details>
<summary>View Screenshots</summary>

## Leaderboard

![Screenshot 2022-04-04 at 1 09 42 PM](https://user-images.githubusercontent.com/31166322/161511983-a5d4d4da-68a3-402f-812f-78bf247e91eb.png)

## Unit testcases

![Screenshot 2022-04-04 at 1 51 32 PM](https://user-images.githubusercontent.com/31166322/161512032-ed246846-0751-4eda-ba11-e550d610871a.png)

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?
