### PR TITLE
chore(rproxy): remove redundant route resolvers

### DIFF
--- a/packages/reverse-proxy-service/src/restricted-spas/index.ts
+++ b/packages/reverse-proxy-service/src/restricted-spas/index.ts
@@ -3,10 +3,11 @@ import resolver from './resolver';
 
 const router = Router();
 
+/* RHEL Development Guide permanent redirect */
 router.get( '/rhel-developer-guide', ( req, res ) => {
   res.redirect( '/rhel-development-guide', 301 );
 } );
-router.get( '/rhel-development-guide', resolver);
+/* Proxy all other apps using resolver */
 router.get( '*', resolver );
 
 export default router;

--- a/packages/reverse-proxy-service/src/spec/restricted-spas.spec.ts
+++ b/packages/reverse-proxy-service/src/spec/restricted-spas.spec.ts
@@ -23,9 +23,9 @@ describe( 'Restricted SPAs - OIDC Auth middleware', () => {
       } );
   } );
 
-  it( '/rhel-development-guide - should redirect for authentication with 302', ( done ) => {
+  it( '/other-app - should redirect for authentication with 302', ( done ) => {
     request( app )
-      .get( '/rhel-development-guide' )
+      .get( '/other-app' )
       .expect( 302 )
       .end( ( err, res ) => {
         if ( err ) {


### PR DESCRIPTION
# Explain the feature/fix

- Removed redundant route for a specific path, since the `*` already does the same thing
- And updated the tests

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
