### PR TITLE
fix(api-catalog-service): updated mongoose validation to avoid require in schema field in db

### DIFF
--- a/packages/api-catalog-service/package-lock.json
+++ b/packages/api-catalog-service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api-catalog",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "api-catalog",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^3.1.2",

--- a/packages/api-catalog-service/package.json
+++ b/packages/api-catalog-service/package.json
@@ -5,7 +5,7 @@
     "className": "ApiCatalog",
     "serviceName": "api-catalog"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "web-components",
     "html"

--- a/packages/api-catalog-service/src/db/specSheet.ts
+++ b/packages/api-catalog-service/src/db/specSheet.ts
@@ -62,7 +62,6 @@ export const SpecSheetSchema: Schema = new Schema(
         },
         schemaEndpoint: {
           type: String,
-          required: true,
         },
         hash: {
           type: String,


### PR DESCRIPTION
# Fixes

# Explain the feature/fix

1. Fixes mongoose validation error on schemaEndpoint required

## Does this PR introduce a breaking change

No

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshots below this line -->

</details>

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?
