### PR TITLE
chore: updating the opc-feedback component version in home-spa

### DIFF
--- a/packages/home-spa/package-lock.json
+++ b/packages/home-spa/package-lock.json
@@ -9479,7 +9479,8 @@
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
           "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -9504,7 +9505,8 @@
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
           "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -10773,7 +10775,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -13415,7 +13418,8 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/packages/home-spa/src/_includes/partials/header.njk
+++ b/packages/home-spa/src/_includes/partials/header.njk
@@ -9,7 +9,7 @@
   crossorigin="anonymous"
 ></script>
 <script
-  src="https://unpkg.com/@one-platform/opc-feedback@0.0.10-prerelease/dist/opc-feedback.js"
+  src="https://unpkg.com/@one-platform/opc-feedback@0.0.12-prerelease/dist/opc-feedback.js"
   integrity="sha384-AH+OgTmX8gp49M9W7oqGwMCVl98k1JBBGvpLfn80Ws5Z923vDa6HXKzQdBXQKb2u"
   crossorigin="anonymous"
 ></script>
@@ -18,14 +18,14 @@
   integrity="sha384-A+qgRjIalaYugVHRmgJhIdF2f9bczb8M//5D5wa7KwjQ8po83pfy9yYsuC5yBrg7"
   crossorigin="anonymous"
 ></script>
-<script 
-  src="https://unpkg.com/@one-platform/opc-base@1.1.7-beta/dist/umd/opc-base.js" 
-  integrity="sha384-ASygq8hTB2fzRmsj592afrUnabfiwqMVOg2r0gdZfLG8EpjSZoWaHmgfhH4xGALS" 
+<script
+  src="https://unpkg.com/@one-platform/opc-base@1.1.7-beta/dist/umd/opc-base.js"
+  integrity="sha384-ASygq8hTB2fzRmsj592afrUnabfiwqMVOg2r0gdZfLG8EpjSZoWaHmgfhH4xGALS"
   crossorigin="anonymous">
 </script>
-<script 
-  src="https://unpkg.com/@one-platform/opc-base@1.1.7-beta/dist/umd/opc-provider.js" 
-  integrity="sha384-BttGWJnWgps9q0OJOETH3T1Oyjm2kUkr7K7YSkzYm8ioDX0ribsJuN1KCcVzMcxv" 
+<script
+  src="https://unpkg.com/@one-platform/opc-base@1.1.7-beta/dist/umd/opc-provider.js"
+  integrity="sha384-BttGWJnWgps9q0OJOETH3T1Oyjm2kUkr7K7YSkzYm8ioDX0ribsJuN1KCcVzMcxv"
   crossorigin="anonymous">
 </script>
 

--- a/packages/home-spa/src/_includes/partials/header.njk
+++ b/packages/home-spa/src/_includes/partials/header.njk
@@ -9,8 +9,7 @@
   crossorigin="anonymous"
 ></script>
 <script
-  src="https://unpkg.com/@one-platform/opc-feedback@0.0.12-prerelease/dist/opc-feedback.js"
-  integrity="sha384-AH+OgTmX8gp49M9W7oqGwMCVl98k1JBBGvpLfn80Ws5Z923vDa6HXKzQdBXQKb2u"
+  src="https://unpkg.com/@one-platform/opc-feedback@0.0.12-prerelease/dist/opc-feedback.js" integrity="sha384-xeRtY4lUHm6jDOgB1DE6qKYBEzL3Nu30zvxWc0+BnVe4x7qyOHekVN9b83J0deSj"
   crossorigin="anonymous"
 ></script>
 <script

--- a/packages/home-spa/src/_includes/partials/header.njk
+++ b/packages/home-spa/src/_includes/partials/header.njk
@@ -9,7 +9,8 @@
   crossorigin="anonymous"
 ></script>
 <script
-  src="https://unpkg.com/@one-platform/opc-feedback@0.0.12-prerelease/dist/opc-feedback.js" integrity="sha384-xeRtY4lUHm6jDOgB1DE6qKYBEzL3Nu30zvxWc0+BnVe4x7qyOHekVN9b83J0deSj"
+  src="https://unpkg.com/@one-platform/opc-feedback@0.0.12-prerelease/dist/opc-feedback.js" 
+  integrity="sha384-xeRtY4lUHm6jDOgB1DE6qKYBEzL3Nu30zvxWc0+BnVe4x7qyOHekVN9b83J0deSj"
   crossorigin="anonymous"
 ></script>
 <script


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "One Platform Developers"
Projects: "One Platform Development"
-->


# Explain the feature/fix
There was an accesibility issue of images not having alt text in home-spa. These images came from opc-feedback component being used in home-spa. this PR aims at updating the version of opc-feedback component used so that the latest version is used which has alt text for all the images being used in that component.

## Does this PR introduce a breaking change

No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->




Lighthouse analytics before the change 

![image](https://user-images.githubusercontent.com/55888723/203713441-051ea808-29f9-4641-8202-42a55efe2b36.png)

Lighthouse analytics after the change

![image](https://user-images.githubusercontent.com/55888723/203713933-bd9f947d-8023-4d9d-afe5-db35657ac365.png)


