### PR TITLE
Fixed Accessibity issues in Home spa 

### DIFF
--- a/packages/home-spa/package-lock.json
+++ b/packages/home-spa/package-lock.json
@@ -9479,7 +9479,8 @@
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
           "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -9504,7 +9505,8 @@
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
           "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -10773,7 +10775,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -13415,7 +13418,8 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/packages/home-spa/src/_includes/components/hero.njk
+++ b/packages/home-spa/src/_includes/components/hero.njk
@@ -1,5 +1,5 @@
 <div class="hero">
-  <img src="/static/img/user.svg" alt="" srcset="">
+  <img src="/static/img/user.svg" alt="user" srcset="">
   <h1 class="hero__title">
       We connect users to <span>an experience</span>
   </h1>

--- a/packages/home-spa/src/contact-us.njk
+++ b/packages/home-spa/src/contact-us.njk
@@ -14,7 +14,7 @@ const contactUsTeamBlock = () => {
         .map((member) => {
           return `
       <div class="team-block__list--item">
-          <img src="/static/img/avatar.svg" alt="">
+          <img src="/static/img/avatar.svg" alt="avatar">
           <span class="name">${member.cn}</span>
           <span class="title">${member.rhatJobTitle}</span>
       </div>`;


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "One Platform Developers"
Projects: "One Platform Development"
-->



### <!-- Any of the keywords: Closes/Fixes/Resolves followed by #issue_id (should be separated by a space only) -->

# Explain the feature/fix

There was an accessibility issue of images not having alt text in home-spa particularly on contact us page and home page (Iussue -https://issues.redhat.com/browse/ONEPLAT-2335)

## Does this PR introduce a breaking change
No

<!-- Yes/No -->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Screenshots

Lighthouse before accessibility changes 
![image](https://user-images.githubusercontent.com/56580582/203935855-52efee2b-278f-4872-a271-a6a703c3e27b.png)
Lighthouse after accessibility changes
![image](https://user-images.githubusercontent.com/56580582/203938592-609c60e8-fcd8-4f26-bc0e-a44a660ef126.png)