### PR TITLE
chore: fixing multiple links for same label (accessibility issue)

### DIFF
--- a/packages/home-spa/src/_includes/components/deploy.njk
+++ b/packages/home-spa/src/_includes/components/deploy.njk
@@ -29,5 +29,5 @@
       develop, deploy and deliver application to your users.
     </p>
   </div>
-  <a target="_blank" rel="noopener noreferrer" class="deploy__get-started" href="console/?new=true">Get Started</a>
+  <a target="_blank" rel="noopener noreferrer" class="deploy__get-started" href="console">Get Started</a>
 </div>


### PR DESCRIPTION
# Explain the feature/fix
There was an accessibility issue regrading the `Get started `button on the page. Two buttons with same label were pointing two different links (http://localhost:4200/console/?new=true and http://localhost:4200/console/)
<!-- Provide a clear explanation of the feature/fix implemented -->

## Does this PR introduce a breaking change

No

