### PR TITLE
fix(lighthouse-spa): fixing accessibility issues in lighthouse-spa

### DIFF
--- a/packages/lighthouse-spa/src/app/dashboard/pages/home/home.component.html
+++ b/packages/lighthouse-spa/src/app/dashboard/pages/home/home.component.html
@@ -38,8 +38,8 @@
                     <div class="pf-u-font-weight-bold">Presets :</div>
                     <div *ngFor="let preset of presets;index as i" class="pf-c-radio">
                         <input type="radio" name="preset" value="{{ preset.value }}" [(ngModel)]="selectedPreset"
-                            class="pf-c-radio__input">
-                        <label for="preset" class="pf-c-radio__label">{{ preset.name }}</label>
+                            class="pf-c-radio__input" id="{{ preset.name }}">
+                        <label for="{{ preset.name }}" class="pf-c-radio__label">{{ preset.name }}</label>
                     </div>
                 </div>
             </div>

--- a/packages/lighthouse-spa/src/app/shared/layouts/app-layout/app-layout.component.html
+++ b/packages/lighthouse-spa/src/app/shared/layouts/app-layout/app-layout.component.html
@@ -26,7 +26,7 @@
                     </li>
                     <li class="pf-c-nav__item">
                         <a href="{{lhDocURL}}" class="pf-c-nav__link" target="_blank" rel="noreferrer noopener"
-                            aria-current="page" routerLinkActive="pf-m-current">Documentation</a>
+                            aria-current="page" routerLinkActive="pf-m-current">Read Docs</a>
                     </li>
                 </ul>
             </nav>


### PR DESCRIPTION
# Fixes
2338 (Accessibility issues)
* Input elements without labels for the form (Screenshot attached)
* Different links for the same label (Documentation)

# Explain the feature/fix

* There was an accessibility issue regrading the `Documentation` label in top banner and Navbar. Two buttons with same label were pointing two different links. Changed the label in Navbar to `Read Docs`
* There was an accessibility issue regrading form labels for the input elements. Updated the labels with suitable id to solve the issue

## Does this PR introduce a breaking change

No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Screenshots
![image](https://user-images.githubusercontent.com/55888723/204532743-0e5b508a-d607-4724-b853-16c3d6839142.png)