### PR TITLE
hotfix: changed base image for reverse proxy

### DIFF
--- a/packages/reverse-proxy-service/Dockerfile
+++ b/packages/reverse-proxy-service/Dockerfile
@@ -1,12 +1,16 @@
-FROM node:16-alpine
+FROM registry.access.redhat.com/ubi8/nodejs-16-minimal
 LABEL Name="one-platform-reverse-proxy" \
-  Version="1.2.0" \
-  Maintainer="mdeshmuk@redhat.com"
+  Version="1.3.0" \
+  maintainer="mdeshmuk@redhat.com"
 
-ENV NODE_ENV=development
-WORKDIR /usr/src
+WORKDIR /opt/app-root/src
 
 ADD . .
+
+USER root
+RUN chmod a+w -R .
+USER 1001
+
 RUN npm install --silent \
   && npm run build
 


### PR DESCRIPTION
# Resolves

Reverse proxy directory permission issue on openshift

# Explain the feature/fix

Changed the base image to `ubi8/nodejs-16-minimal` and adjusted the permissions for the working directory.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did tests pass?
