### PR TITLE
fix(apps): added sparse + unique keys for hosting

### DIFF
--- a/packages/apps-service/src/modules/projects/model.ts
+++ b/packages/apps-service/src/modules/projects/model.ts
@@ -52,9 +52,9 @@ const ProjectSchema = new Schema<ProjectModel, ProjectModelStatic>({
     applications: [
       {
         _id: false,
-        appId: { type: String, required: true, unique: true },
-        name: { type: String, required: true, unique: true },
-        url: { type: String, required: true, unique: true },
+        appId: { type: String, required: true, },
+        name: { type: String, required: true, },
+        url: { type: String, required: true, },
         type: { type: String },
         createdOn: { type: Date, default: Date.now },
         createdBy: { type: String },
@@ -115,7 +115,19 @@ const ProjectSchema = new Schema<ProjectModel, ProjectModelStatic>({
   updatedOn: { type: Date, default: Date.now },
 });
 
-ProjectSchema.index({ name: 1, ownerId: 1 });
+ProjectSchema.index({ name: 1, ownerId: 1 }, { unique: true, });
+ProjectSchema.index(
+  { 'hosting.applications.appId': 1 },
+  { sparse: true, unique: true }
+);
+ProjectSchema.index(
+  { 'hosting.applications.name': 1 },
+  { sparse: true, unique: true }
+);
+ProjectSchema.index(
+  { 'hosting.applications.url': 1 },
+  { sparse: true, unique: true }
+);
 
 ProjectSchema.static(
   'isAuthorized',


### PR DESCRIPTION
# Fixes

Duplicate key error for empty hosting array in apps service.

### <!-- Any of the keywords: Closes/Fixes/Resolves followed by #issue_id (should be separated by a space only) -->

# Explain the feature/fix

Added unique and sparse keys for `hosting.appId`, `hosting.name` and `hosting.url` fields.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?
