### PR TITLE
feat(search-service): adding /sitemap endpoint and new schema in sear…

### DIFF
--- a/packages/search-service/service.ts
+++ b/packages/search-service/service.ts
@@ -10,6 +10,7 @@ import { SearchMapResolver } from './src/search-mapping/resolver';
 import searchMapSchema from './src/search-mapping/typedef.graphql';
 import database from './src/setup/database';
 import { NODE_ENV, PORT } from './src/setup/env';
+import { getSiteMap } from './src/search-sitemap/resolver';
 
 (async function setConfig() {
   /* Setup database connection */
@@ -20,6 +21,11 @@ import { NODE_ENV, PORT } from './src/setup/env';
 }());
 
 const app = express();
+
+app.get('/sitemap', async (req, res) => {
+  const data = await getSiteMap(req);
+  res.send(data);
+});
 
 app.use(morgan(':method :url :status :res[content-length] - :response-time ms'));
 const schema = mergeSchemas({

--- a/packages/search-service/src/search-sitemap/resolver.ts
+++ b/packages/search-service/src/search-sitemap/resolver.ts
@@ -1,0 +1,21 @@
+import { Request } from 'express';
+import { SiteMaps } from './schema';
+
+export const getSiteMap = async (req: Request) => {
+  const { contentType } = req.query;
+
+  const sitemapData = (await SiteMaps.find()).map((item) => ({
+    url: item.url,
+    contentType: item.contentType,
+    lastModified: new Date().toISOString(),
+  }));
+
+  const filteredSitemapData = contentType
+    ? sitemapData.filter((item) => item.contentType === contentType)
+    : sitemapData;
+
+  return {
+    count: filteredSitemapData.length,
+    data: filteredSitemapData,
+  };
+};

--- a/packages/search-service/src/search-sitemap/schema.ts
+++ b/packages/search-service/src/search-sitemap/schema.ts
@@ -1,0 +1,14 @@
+import {
+  Document, Model, model, Schema,
+} from 'mongoose';
+
+export const SiteMapSchema: Schema = new Schema({
+  url: { type: String },
+  contentType: { type: String },
+});
+
+interface SiteMapModel extends Sitemap, Document {}
+
+interface SiteMapStatic extends Model<SiteMapModel> {}
+
+export const SiteMaps: Model<SiteMapModel> = model<SiteMapModel, SiteMapStatic>('SiteMap', SiteMapSchema);

--- a/packages/search-service/src/search-sitemap/types.d.ts
+++ b/packages/search-service/src/search-sitemap/types.d.ts
@@ -1,0 +1,4 @@
+declare type Sitemap = {
+  url: string;
+  contentType: string;
+};


### PR DESCRIPTION


<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "One Platform Developers"
Projects: "One Platform Development"
-->

# Closes/Fixes/Resolves
ONEPLAT-2405
### <!-- Any of the keywords: Closes/Fixes/Resolves followed by #issue_id (should be separated by a space only) -->

# Explain the feature/fix

Adding a new `/sitemap` REST endpoint in the search-service along with the new Schema to store the web crawling configuration for static web apps.
<!-- Provide a clear explanation of the feature/fix implemented -->

## Does this PR introduce a breaking change

No
