### PR TITLE
feat(feedback-service): adding searchFeedbacks endpoint in feedbacks

### DIFF
--- a/packages/feedback-service/src/feedbacks/typedef.graphql
+++ b/packages/feedback-service/src/feedbacks/typedef.graphql
@@ -113,6 +113,10 @@ type Query {
   getFeedbackById(
     id: ID!
     ): FeedbackType
+  """
+  Search the Feedbacks by a search query string
+  """
+  searchFeedbacks(searchQuery:String):PaginatedFeedbackType
 }
 
 type Mutation {


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "feat/fix/docs(#issue_id): <PR Subject>"
Assignees: "One Platform Developers"
Projects: "One Platform Development"
-->


# Explain the feature/fix
Added a searchFeedbacks endpoint in the feedback service to search multiple fields of feedback schema against a query string
<!-- Provide a clear explanation of the feature/fix implemented -->

## Does this PR introduce a breaking change

No 
