### PR TITLE
feat(feedback): add frontend url field in configs

### DIFF
--- a/packages/feedback-service/src/feedback-config/schema.ts
+++ b/packages/feedback-service/src/feedback-config/schema.ts
@@ -13,6 +13,9 @@ export const FeedbackConfigSchema: Schema = new Schema({
     required: true,
     unique: true,
   },
+  projectFrontendUrl: {
+    type: String,
+  },
   isEnabled: { type: Boolean, default: true },
   sourceType: { type: String, enum: ['JIRA', 'GITLAB', 'GITHUB', 'EMAIL'], default: 'JIRA' },
   sourceApiUrl: { type: String },

--- a/packages/feedback-service/src/feedback-config/typedef.graphql
+++ b/packages/feedback-service/src/feedback-config/typedef.graphql
@@ -24,6 +24,7 @@ type FeedbackConfigType {
   sourceHeaders: [FeedbackHeaderType]
   projectKey: String
   feedbackEmail: String
+  projectFrontendUrl: String
 }
 
 input FeedbackConfigInput {
@@ -36,6 +37,7 @@ input FeedbackConfigInput {
   sourceHeaders: [FeedbackHeaderInput]
   projectKey: String
   feedbackEmail: String
+  projectFrontendUrl: String
 }
 
 type Query {

--- a/packages/feedback-service/src/helpers.ts
+++ b/packages/feedback-service/src/helpers.ts
@@ -324,14 +324,23 @@ function createEmailTemplate(
 ) {
   const appName = projectId.split( '/' )[ 1 ] ?? projectId;
 
+  const getPageUrl = ( str: string ) => {
+    try {
+      const url = new URL( str );
+      return url.toString();
+    } catch ( err ) {
+      return new URL( str, config.projectFrontendUrl ?? process.env.FEEDBACK_CLIENT!.toLowerCase() );
+    }
+  }
+
+  const pageUrl = getPageUrl(feedback.stackInfo?.path ?? '/');
+
   const emailBody = `
 Hi ${userInfo[0].cn},<br/><br/>
 We have received the ${feedback.category.toLowerCase()} for the ${appName}<br/><br/>
 
 Summary: ${feedback.summary}<br/><br/>
-URL: ${new URL(process.env.FEEDBACK_CLIENT as string).origin}${
-    (feedback.stackInfo as any)?.path
-  }<br/><br/>
+URL: ${pageUrl}<br/><br/>
 
 ${
   feedback.ticketUrl

--- a/packages/feedback-service/src/types.d.ts
+++ b/packages/feedback-service/src/types.d.ts
@@ -92,6 +92,7 @@ type FeedbackConfigType = {
   }>;
   projectKey: string;
   feedbackEmail: string;
+  projectFrontendUrl: string;
 };
 
 type FeedbackConfigInput = {


### PR DESCRIPTION
# Explain the feature/fix

Added a configurable field in the feedback config for a base url/url prefix for the feedback email templates.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?