### PR TITLE
fix(dockerfile): Replaced npm commands with node

### DIFF
--- a/packages/api-gateway-service/Dockerfile
+++ b/packages/api-gateway-service/Dockerfile
@@ -13,4 +13,4 @@ RUN npm install --silent && \
 ENV PORT 8080
 EXPOSE 8080
 
-CMD [ "npm", "start"]
+CMD [ "node", "dist/bundle.js"]

--- a/packages/notifications-service/Dockerfile
+++ b/packages/notifications-service/Dockerfile
@@ -11,4 +11,4 @@ RUN npm install --silent && npm run build
 
 EXPOSE 8080
 
-CMD ["npm", "start"]
+CMD ["node", "dist/index.js"]

--- a/packages/search-service/Dockerfile
+++ b/packages/search-service/Dockerfile
@@ -14,4 +14,4 @@ RUN npm install --silent && \
 ENV PORT 8080
 EXPOSE 8080
 
-CMD [ "npm", "start"]
+CMD [ "node", "dist/bundle.js"]


### PR DESCRIPTION
# Explain the feature/fix

Simplified the Dockerfile CMD instructions to use "node" instead of "npm", ensuring better compatibility and reducing unnecessary dependencies. This change improves the reliability and efficiency of the Docker containers for the services.

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?