### PR TITLE
fix(reverse-proxy): increase request header size limit

### DIFF
--- a/packages/reverse-proxy-service/src/server.ts
+++ b/packages/reverse-proxy-service/src/server.ts
@@ -14,8 +14,6 @@ import oidcAuth from './middleware/oidcAuth';
 import { updateApplicationCache } from './utils/applicationCache';
 import http from 'http';
 
-declare module 'http' { interface Agent { maxHeaderSize?: number; } }
-
 const MAX_HEADER_SIZE = 16 * 1024 * 1024; // 16MB
 
 ( http.globalAgent as http.Agent ).maxHeaderSize = MAX_HEADER_SIZE;

--- a/packages/reverse-proxy-service/src/server.ts
+++ b/packages/reverse-proxy-service/src/server.ts
@@ -13,15 +13,12 @@ import { COOKIE_SECRET } from './setup/env';
 import oidcAuth from './middleware/oidcAuth';
 import { updateApplicationCache } from './utils/applicationCache';
 import http from 'http';
-import https from 'https';
 
 declare module 'http' { interface Agent { maxHeaderSize?: number; } }
-declare module 'https' { interface Agent { maxHeaderSize?: number; } }
 
 const MAX_HEADER_SIZE = 16 * 1024 * 1024; // 16MB
 
 ( http.globalAgent as http.Agent ).maxHeaderSize = MAX_HEADER_SIZE;
-( https.globalAgent as https.Agent ).maxHeaderSize = MAX_HEADER_SIZE;
 
 const getServer = async () => {
   const server = express();

--- a/packages/reverse-proxy-service/src/server.ts
+++ b/packages/reverse-proxy-service/src/server.ts
@@ -12,6 +12,16 @@ import store from './setup/store';
 import { COOKIE_SECRET } from './setup/env';
 import oidcAuth from './middleware/oidcAuth';
 import { updateApplicationCache } from './utils/applicationCache';
+import http from 'http';
+import https from 'https';
+
+declare module 'http' { interface Agent { maxHeaderSize?: number; } }
+declare module 'https' { interface Agent { maxHeaderSize?: number; } }
+
+const MAX_HEADER_SIZE = 16 * 1024 * 1024; // 16MB
+
+( http.globalAgent as http.Agent ).maxHeaderSize = MAX_HEADER_SIZE;
+( https.globalAgent as https.Agent ).maxHeaderSize = MAX_HEADER_SIZE;
 
 const getServer = async () => {
   const server = express();

--- a/packages/reverse-proxy-service/src/types/http.d.ts
+++ b/packages/reverse-proxy-service/src/types/http.d.ts
@@ -1,0 +1,7 @@
+import * as http from 'http';
+
+declare module 'http' {
+    interface Agent {
+        maxHeaderSize?: number;
+    }
+}

--- a/packages/reverse-proxy-service/tsconfig.json
+++ b/packages/reverse-proxy-service/tsconfig.json
@@ -50,7 +50,10 @@
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                             /* List of folders to include type definitions from. */
+    "typeRoots": [
+      "src/types",
+      "node_modules/@types"
+    ],
     // "types": [],                                 /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */


### PR DESCRIPTION
<!--
Follow the steps to create the PR:

Subject: "fix: Increase request header size limit by extending http and https Agent types"

Assignees: "One Platform Developers"
Projects: "One Platform Development"
-->

# Explain the feature/fix

- Extended the `http.Agent` types to include the `maxHeaderSize` property.
- Set the global agent's `maxHeaderSize` to 16MB to allow larger request headers.

## Does this PR introduce a breaking change

<!-- Yes/No -->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Screenshots

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshots below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did tests pass?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demoed and the design review approved?
