### PR TITLE
feat(api-gateway): add user blacklist feature

### DIFF
--- a/packages/api-gateway-service/.env.example
+++ b/packages/api-gateway-service/.env.example
@@ -11,3 +11,6 @@ CONFIG_PATH=
 
 ## Keycloak Public Key for JWT Token verification
 KEYCLOAK_PUBKEY=
+
+## User blacklist (optional, loaded once at startup)
+BLACKLIST_FILE_PATH=./blacklist.txt

--- a/packages/api-gateway-service/.gitignore
+++ b/packages/api-gateway-service/.gitignore
@@ -5,5 +5,8 @@ node_modules
 # ignore dist
 dist
 
+# Local blacklist copy
+blacklist.txt
+
 # Logs
 npm-debug.log*

--- a/packages/api-gateway-service/README.md
+++ b/packages/api-gateway-service/README.md
@@ -14,6 +14,31 @@ API Gateway handles all the tasks involved in accepting and processing up to hun
 
 *Note:* Before starting the gateway, also make sure the microservices in this project are configured properly.
 
+## User blacklist
+
+When `BLACKLIST_FILE_PATH` is set, the gateway loads a text file of blocked user identifiers once at startup. Restart the gateway to pick up file changes.
+
+```env
+BLACKLIST_FILE_PATH=./blacklist.txt
+```
+
+See [`blacklist.example.txt`](blacklist.example.txt). One **uid** or **email** per line; empty lines and `#` comments are ignored.
+
+Regenerate from Compass:
+
+```bash
+node scripts/generate-blacklist-from-compass-output.mjs <catalog-entity.json>
+```
+
+Matching uses the **token owner** identity (not `rhatUUID`):
+
+- **JWT:** Keycloak `uid` and `email` (or `mail`) from the access token
+- **API key:** owning user's `uid` and `mail` from User Group when `ownerType` is `User`
+
+Downstream forwarding still uses `rhatUUID` in Apollo context / `X-OP-User-ID` for JWTs. Group-owned API keys are not evaluated against the blacklist.
+
+OpenShift: [openshift/README.md](openshift/README.md).
+
 ## Running Tests
 
 ```bash

--- a/packages/api-gateway-service/blacklist.example.txt
+++ b/packages/api-gateway-service/blacklist.example.txt
@@ -1,0 +1,3 @@
+# One identifier per line (uid or email)
+jdoe
+blocked.user@redhat.com

--- a/packages/api-gateway-service/jest.config.js
+++ b/packages/api-gateway-service/jest.config.js
@@ -16,7 +16,8 @@ module.exports = {
   },
   "collectCoverage": true,
   "testMatch": [
-    "**/src/e2e/*.spec.(ts|tsx|js)"
+    "**/src/e2e/*.spec.(ts|tsx|js)",
+    "**/src/blacklist/*.spec.(ts|tsx|js)"
   ],
   "testEnvironment": "node"
 }

--- a/packages/api-gateway-service/package.json
+++ b/packages/api-gateway-service/package.json
@@ -24,7 +24,7 @@
     "dev": "webpack --watch --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "build:dev": "webpack --config webpack.dev.js",
-    "test": "echo \"Error: no test specified\""
+    "test": "jest"
   },
   "author": {
     "name": "Rigin Oommen",

--- a/packages/api-gateway-service/service.ts
+++ b/packages/api-gateway-service/service.ts
@@ -6,7 +6,7 @@ if ( process.env.NODE_ENV === 'test' ) {
   dotenv.config();
 }
 
-import { ApolloServer, AuthenticationError } from 'apollo-server-express';
+import { ApolloServer, AuthenticationError, ForbiddenError } from 'apollo-server-express';
 import express from 'express';
 import http from 'http';
 import cors from 'cors';
@@ -15,6 +15,14 @@ import { stitchedSchemas } from './src/stitch-schema';
 import { verifyAPIKey, verifyJwtToken } from './src/verify-token';
 import path from 'path';
 import helmet from 'helmet';
+import {
+  getBlacklistIndex,
+  initBlacklist,
+  isBlacklistEnabled,
+} from './src/blacklist/blacklist';
+import { extractTokenOwnerClaims } from './src/blacklist/extractUserClaims';
+import { extractOwnerClaims } from './src/blacklist/extractOwnerClaims';
+import { isUserBlacklisted } from './src/blacklist/isUserBlacklisted';
 
 /* Setting base url and port for the server */
 const baseUrl = process.env.BASE_URL ?? '/';
@@ -38,6 +46,15 @@ app.use( helmet( {
 /* include cors middleware */
 app.use( cors() );
 
+function assertNotBlacklisted( claims: { uid?: string; email?: string } ): void {
+  if ( !isBlacklistEnabled() ) {
+    return;
+  }
+  if ( isUserBlacklisted( getBlacklistIndex(), claims ) ) {
+    throw new ForbiddenError( 'Access denied' );
+  }
+}
+
 const context = ({ req, connection }: any) => {
   const authorizationHeader = req?.headers?.authorization || connection?.context?.Authorization;
 
@@ -52,71 +69,96 @@ const context = ({ req, connection }: any) => {
   const token = authorizationHeader.split( ' ' )[ 1 ];
 
   if ( uuidValidate( token ) ) {
-    return verifyAPIKey(token)
-      .then((res) => ({ uid: res._id, roles: res.roles, scopes: res.scopes, token }))
-      .catch((err) => {
-        throw new AuthenticationError(err.message);
-      });
-  } else {
-    return verifyJwtToken( token, ( err: any, payload: any ) => {
-      if ( err ) {
-        throw new AuthenticationError( err.message );
-      }
-      return { uid: payload.rhatUUID, roles: payload.role, scope: payload.scope?.split(' '), token };
-    } );
-  }
-};
-
-stitchedSchemas()
-  .then( schema => {
-    /* Defining the Apollo Server */
-    const apollo = new ApolloServer( {
-      subscriptions: {
-        path: subsciptionsBaseUrl,
-      },
-      schema,
-      context,
-      introspection: true,
-      tracing: process.env.NODE_ENV !== 'production',
-      playground: <any>{
-        title: 'API Gateway',
-        settings: {
-          'request.credentials': 'include'
-        },
-        headers: {
-          Authorization: `Bearer <ENTER_API_KEY_HERE>`, /* lgtm [js/hardcoded-credentials] */
-        },
-      },
-      plugins: [
-        {
-          requestDidStart: ( requestContext ) => {
-            if ( requestContext.request.http?.headers.has( 'x-apollo-tracing' ) ) {
-              return;
-            }
-            console.log( new Date().toISOString(), `- Incoming ${ requestContext.request.http?.method } request from: ${ requestContext.request.http?.headers.get( 'origin' ) || 'unknown' }`, `- via ${ requestContext.request.http?.headers.get( 'user-agent' ) }` );
-          }
+    return verifyAPIKey( token )
+      .then( ( res ) => {
+        if ( res.ownerType === 'User' && res.owner ) {
+          assertNotBlacklisted( extractOwnerClaims( res.owner ) );
         }
-      ],
-      formatError: error => ( {
-        message: error.message,
-        locations: error.locations,
-        path: error.path,
-        ...error.extensions,
-      } ),
-    } );
+        return { uid: res._id, roles: res.roles, scopes: res.scopes, token };
+      } )
+      .catch( ( err ) => {
+        if ( err instanceof ForbiddenError ) {
+          throw err;
+        }
+        throw new AuthenticationError( err.message );
+      } );
+  }
 
-    /* Applying apollo middleware to express server */
-    apollo.applyMiddleware( { app, path: baseUrl } );
-    apollo.installSubscriptionHandlers( server );
-  } )
-  .catch( err => {
-    console.error( err );
-    throw err;
+  return new Promise( ( resolve, reject ) => {
+    verifyJwtToken( token, ( err: any, payload: any ) => {
+      if ( err ) {
+        reject( new AuthenticationError( err.message ) );
+        return;
+      }
+      try {
+        assertNotBlacklisted( extractTokenOwnerClaims( payload ) );
+        resolve( {
+          uid: payload.rhatUUID,
+          roles: payload.role,
+          scope: payload.scope?.split( ' ' ),
+          token,
+        } );
+      } catch ( blacklistErr ) {
+        reject( blacklistErr );
+      }
+    } );
   } );
+};
 
 /*  Creating the server based on the environment */
 const server = http.createServer( app );
 
-export default server.listen( port, () => {
-  console.log( `Gateway Running on ${ process.env.NODE_ENV } environment at port ${ port }` );
+async function startGateway(): Promise<void> {
+  await initBlacklist();
+
+  const schema = await stitchedSchemas();
+
+  const apollo = new ApolloServer( {
+    subscriptions: {
+      path: subsciptionsBaseUrl,
+    },
+    schema,
+    context,
+    introspection: true,
+    tracing: process.env.NODE_ENV !== 'production',
+    playground: <any>{
+      title: 'API Gateway',
+      settings: {
+        'request.credentials': 'include'
+      },
+      headers: {
+        Authorization: `Bearer <ENTER_API_KEY_HERE>`, /* lgtm [js/hardcoded-credentials] */
+      },
+    },
+    plugins: [
+      {
+        requestDidStart: ( requestContext ) => {
+          if ( requestContext.request.http?.headers.has( 'x-apollo-tracing' ) ) {
+            return;
+          }
+          console.log( new Date().toISOString(), `- Incoming ${ requestContext.request.http?.method } request from: ${ requestContext.request.http?.headers.get( 'origin' ) || 'unknown' }`, `- via ${ requestContext.request.http?.headers.get( 'user-agent' ) }` );
+        }
+      }
+    ],
+    formatError: error => ( {
+      message: error.message,
+      locations: error.locations,
+      path: error.path,
+      ...error.extensions,
+    } ),
+  } );
+
+  apollo.applyMiddleware( { app, path: baseUrl } );
+  apollo.installSubscriptionHandlers( server );
+
+  server.listen( port, () => {
+    console.log( `Gateway Running on ${ process.env.NODE_ENV } environment at port ${ port }` );
+  } );
+}
+
+startGateway().catch( err => {
+  console.error( err );
+  process.exit( 1 );
 } );
+
+export default server;

--- a/packages/api-gateway-service/src/blacklist/blacklist.ts
+++ b/packages/api-gateway-service/src/blacklist/blacklist.ts
@@ -1,0 +1,28 @@
+import { loadBlacklistFromFile } from './loadBlacklistFromFile';
+import { BlacklistIndex } from './types';
+
+const emptyIndex = (): BlacklistIndex => ({ entries: new Set<string>() });
+
+let blacklistIndex: BlacklistIndex = emptyIndex();
+
+function getBlacklistFilePath(): string | undefined {
+  const path = process.env.BLACKLIST_FILE_PATH?.trim();
+  return path || undefined;
+}
+
+export function isBlacklistEnabled(): boolean {
+  return Boolean(getBlacklistFilePath());
+}
+
+export function getBlacklistIndex(): BlacklistIndex {
+  return blacklistIndex;
+}
+
+export async function initBlacklist(): Promise<void> {
+  const filePath = getBlacklistFilePath();
+  if (!filePath) {
+    blacklistIndex = emptyIndex();
+    return;
+  }
+  blacklistIndex = await loadBlacklistFromFile(filePath);
+}

--- a/packages/api-gateway-service/src/blacklist/extractOwnerClaims.spec.ts
+++ b/packages/api-gateway-service/src/blacklist/extractOwnerClaims.spec.ts
@@ -1,0 +1,46 @@
+import { extractOwnerClaims } from './extractOwnerClaims';
+import { parseBlacklistFile } from './parseBlacklistFile';
+import { isUserBlacklisted } from './isUserBlacklisted';
+
+describe('extractOwnerClaims', () => {
+  it('maps uid and mail to UserClaims', () => {
+    expect(
+      extractOwnerClaims({ uid: 'jdoe', mail: 'jdoe@redhat.com' })
+    ).toEqual({
+      uid: 'jdoe',
+      email: 'jdoe@redhat.com',
+    });
+  });
+
+  it('omits missing fields', () => {
+    expect(extractOwnerClaims({})).toEqual({
+      uid: undefined,
+      email: undefined,
+    });
+  });
+});
+
+describe('API key owner blacklist', () => {
+  const index = parseBlacklistFile('jdoe\nblocked@redhat.com');
+
+  it('blocks User owner when uid is listed', () => {
+    const claims = extractOwnerClaims({ uid: 'jdoe', mail: 'jdoe@redhat.com' });
+    expect(isUserBlacklisted(index, claims)).toBe(true);
+  });
+
+  it('blocks User owner when mail is listed', () => {
+    const claims = extractOwnerClaims({
+      uid: 'other',
+      mail: 'blocked@redhat.com',
+    });
+    expect(isUserBlacklisted(index, claims)).toBe(true);
+  });
+
+  it('allows User owner when neither field matches', () => {
+    const claims = extractOwnerClaims({
+      uid: 'allowed',
+      mail: 'allowed@redhat.com',
+    });
+    expect(isUserBlacklisted(index, claims)).toBe(false);
+  });
+});

--- a/packages/api-gateway-service/src/blacklist/extractOwnerClaims.ts
+++ b/packages/api-gateway-service/src/blacklist/extractOwnerClaims.ts
@@ -1,0 +1,13 @@
+import { UserClaims } from './types';
+
+export type ApiKeyOwnerUser = {
+  uid?: string;
+  mail?: string;
+};
+
+export function extractOwnerClaims(owner: ApiKeyOwnerUser): UserClaims {
+  return {
+    uid: typeof owner.uid === 'string' ? owner.uid : undefined,
+    email: typeof owner.mail === 'string' ? owner.mail : undefined,
+  };
+}

--- a/packages/api-gateway-service/src/blacklist/extractUserClaims.spec.ts
+++ b/packages/api-gateway-service/src/blacklist/extractUserClaims.spec.ts
@@ -1,0 +1,49 @@
+import { extractTokenOwnerClaims } from './extractUserClaims';
+import { parseBlacklistFile } from './parseBlacklistFile';
+import { isUserBlacklisted } from './isUserBlacklisted';
+
+describe('extractTokenOwnerClaims', () => {
+  it('uses uid and email from JWT payload', () => {
+    expect(
+      extractTokenOwnerClaims({
+        uid: 'jdoe',
+        email: 'jdoe@redhat.com',
+        rhatUUID: 'uuid-should-not-be-used',
+      })
+    ).toEqual({
+      uid: 'jdoe',
+      email: 'jdoe@redhat.com',
+    });
+  });
+
+  it('falls back to mail when email claim is absent', () => {
+    expect(
+      extractTokenOwnerClaims({
+        uid: 'jdoe',
+        mail: 'jdoe@redhat.com',
+        rhatUUID: 'uuid-123',
+      })
+    ).toEqual({
+      uid: 'jdoe',
+      email: 'jdoe@redhat.com',
+    });
+  });
+
+  it('does not blacklist when only rhatUUID matches a listed uuid-like entry', () => {
+    const index = parseBlacklistFile('uuid-123');
+    const claims = extractTokenOwnerClaims({
+      rhatUUID: 'uuid-123',
+      uid: 'allowed-user',
+    });
+    expect(isUserBlacklisted(index, claims)).toBe(false);
+  });
+
+  it('blacklists token owner by uid when listed', () => {
+    const index = parseBlacklistFile('jdoe');
+    const claims = extractTokenOwnerClaims({
+      uid: 'jdoe',
+      rhatUUID: 'other-uuid',
+    });
+    expect(isUserBlacklisted(index, claims)).toBe(true);
+  });
+});

--- a/packages/api-gateway-service/src/blacklist/extractUserClaims.ts
+++ b/packages/api-gateway-service/src/blacklist/extractUserClaims.ts
@@ -1,0 +1,24 @@
+// Identity for blacklist is the JWT token owner (uid / email only, never rhatUUID).
+
+import { UserClaims } from './types';
+
+/** Keycloak uid of the human token owner. */
+export function extractTokenOwnerClaims(
+  payload: Record<string, unknown>,
+): UserClaims {
+  const uid = typeof payload.uid === 'string' ? payload.uid : undefined;
+  const email =
+    typeof payload.email === 'string'
+      ? payload.email
+      : typeof payload.mail === 'string'
+        ? payload.mail
+        : undefined;
+  return { uid, email };
+}
+
+/** @deprecated Use extractTokenOwnerClaims */
+export function extractUserClaims(
+  payload: Record<string, unknown>,
+): UserClaims {
+  return extractTokenOwnerClaims(payload);
+}

--- a/packages/api-gateway-service/src/blacklist/isUserBlacklisted.ts
+++ b/packages/api-gateway-service/src/blacklist/isUserBlacklisted.ts
@@ -1,0 +1,23 @@
+import { BlacklistIndex, UserClaims } from './types';
+
+export function isUserBlacklisted(
+  index: BlacklistIndex,
+  user: UserClaims,
+): boolean {
+  const { entries } = index;
+  if (entries.size === 0) {
+    return false;
+  }
+
+  if (user.uid && entries.has(user.uid)) {
+    console.info('user is blacklisted by uid', user);
+    return true;
+  }
+
+  if (user.email && entries.has(user.email.toLowerCase())) {
+    console.info('user is blacklisted by email', user);
+    return true;
+  }
+
+  return false;
+}

--- a/packages/api-gateway-service/src/blacklist/loadBlacklistFromFile.ts
+++ b/packages/api-gateway-service/src/blacklist/loadBlacklistFromFile.ts
@@ -1,0 +1,19 @@
+import { promises as fs } from 'fs';
+import { parseBlacklistFile } from './parseBlacklistFile';
+import { BlacklistIndex } from './types';
+
+const emptyIndex = (): BlacklistIndex => ({ entries: new Set<string>() });
+
+export async function loadBlacklistFromFile(
+  path: string
+): Promise<BlacklistIndex> {
+  try {
+    const content = await fs.readFile(path, 'utf8');
+    const index = parseBlacklistFile(content);
+    console.info(`blacklist loaded: ${index.entries.size} entries`);
+    return index;
+  } catch (err) {
+    console.error('failed to load blacklist file', { path, err });
+    return emptyIndex();
+  }
+}

--- a/packages/api-gateway-service/src/blacklist/parseBlacklistFile.spec.ts
+++ b/packages/api-gateway-service/src/blacklist/parseBlacklistFile.spec.ts
@@ -1,0 +1,50 @@
+import { parseBlacklistFile } from './parseBlacklistFile';
+import { isUserBlacklisted } from './isUserBlacklisted';
+
+describe('parseBlacklistFile', () => {
+  it('ignores empty lines and comments', () => {
+    const index = parseBlacklistFile(`
+# comment
+jdoe
+
+blocked@example.com
+    `);
+    expect(index.entries.size).toBe(2);
+    expect(index.entries.has('jdoe')).toBe(true);
+    expect(index.entries.has('blocked@example.com')).toBe(true);
+  });
+
+  it('keeps values containing colons as literal entries', () => {
+    const index = parseBlacklistFile('user:name@example.com');
+    expect(index.entries.has('user:name@example.com')).toBe(true);
+  });
+});
+
+describe('isUserBlacklisted', () => {
+  const index = parseBlacklistFile('jdoe\nblocked@example.com\nuuid-123');
+
+  it('matches uid', () => {
+    expect(isUserBlacklisted(index, { uid: 'jdoe' })).toBe(true);
+  });
+
+  it('matches email case-insensitively', () => {
+    expect(isUserBlacklisted(index, { email: 'Blocked@Example.com' })).toBe(
+      true
+    );
+  });
+
+  it('returns false when no field matches', () => {
+    expect(
+      isUserBlacklisted(index, {
+        uid: 'other',
+        email: 'other@example.com',
+      })
+    ).toBe(false);
+  });
+
+  it('returns false for empty blacklist', () => {
+    expect(isUserBlacklisted({ entries: new Set() }, { uid: 'jdoe' })).toBe(
+      false
+    );
+  });
+});

--- a/packages/api-gateway-service/src/blacklist/parseBlacklistFile.ts
+++ b/packages/api-gateway-service/src/blacklist/parseBlacklistFile.ts
@@ -1,0 +1,15 @@
+import { BlacklistIndex } from './types';
+
+export function parseBlacklistFile(content: string): BlacklistIndex {
+  const entries = new Set<string>();
+
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith('#')) {
+      continue;
+    }
+    entries.add(trimmed);
+  }
+
+  return { entries };
+}

--- a/packages/api-gateway-service/src/blacklist/types.ts
+++ b/packages/api-gateway-service/src/blacklist/types.ts
@@ -1,0 +1,8 @@
+export type BlacklistIndex = {
+  entries: Set<string>;
+};
+
+export type UserClaims = {
+  uid?: string;
+  email?: string;
+};

--- a/packages/api-gateway-service/src/verify-token.ts
+++ b/packages/api-gateway-service/src/verify-token.ts
@@ -37,10 +37,22 @@ export function verifyJwtToken ( token: string, callback: any ) {
   return JWT.verify( token, getPublicKey(), callback );
 }
 
+export type ValidatedApiKey = {
+  _id: string;
+  ownerType?: string;
+  owner?: {
+    uid?: string;
+    mail?: string;
+  };
+  access?: Array<{ role: string; microservice: string }>;
+  roles?: string[];
+  scopes?: string[];
+};
+
 /**
  * Verifies the API Key
  */
-export function verifyAPIKey ( accessToken: string ) {
+export function verifyAPIKey ( accessToken: string ): Promise<ValidatedApiKey> {
   const userGroupAPI = microservices.find( service => service.name === 'User Group' );
   if ( !userGroupAPI ) {
     throw new Error( 'API Key Config error. User Group not configured properly.' );
@@ -56,6 +68,13 @@ export function verifyAPIKey ( accessToken: string ) {
         query ValidateAPIKey($accessToken: String!) {
           apiKey: validateAPIKey(accessToken: $accessToken) {
             _id
+            ownerType
+            owner {
+              ... on UserType {
+                uid
+                mail
+              }
+            }
             access {
               role
               microservice

--- a/packages/api-gateway-service/webpack.common.js
+++ b/packages/api-gateway-service/webpack.common.js
@@ -26,6 +26,8 @@ module.exports = {
   output: {
     filename: 'bundle.js',
     path: path.resolve( __dirname, 'dist' ),
+    // MD4 is unavailable under OpenSSL 3 (Node 17+)
+    hashFunction: 'sha256',
   },
   target: 'node',
   externals: [ nodeExternals() ],


### PR DESCRIPTION
# Explain the feature/fix

- Introduced a user blacklist functionality that loads blocked user identifiers from a specified file at startup.
- Added support for a new environment variable `BLACKLIST_FILE_PATH` to configure the blacklist file location.
- Implemented related functions for managing the blacklist, including loading from file and checking user claims against the blacklist.
- Updated README with instructions on using the blacklist feature and provided an example blacklist file.
- Enhanced test coverage for blacklist functionality.

Assisted-By: Cursor <cursoragent@cursor.com>

## Does this PR introduce a breaking change

No.

## Screenshots

N/A

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Does the change have appropriate unit tests?
- [x] Did tests pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demoed and the design review approved?